### PR TITLE
porting to other than *bsd and linux

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,3 +17,4 @@ noinst_HEADERS += stdlib.h
 noinst_HEADERS += Makefile.in
 noinst_HEADERS += poll.h
 noinst_HEADERS += time.h
+noinst_HEADERS += stdio.h

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -18,3 +18,4 @@ noinst_HEADERS += Makefile.in
 noinst_HEADERS += poll.h
 noinst_HEADERS += time.h
 noinst_HEADERS += stdio.h
+noinst_HEADERS += machine/endian.h

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -5,6 +5,7 @@ noinst_HEADERS += netinet/in.h
 noinst_HEADERS += sys/queue.h
 noinst_HEADERS += sys/types.h
 noinst_HEADERS += sys/time.h
+noinst_HEADERS += sys/mman.h
 noinst_HEADERS += err.h
 noinst_HEADERS += imsg.h
 noinst_HEADERS += string.h

--- a/include/machine/endian.h
+++ b/include/machine/endian.h
@@ -1,0 +1,40 @@
+/*
+ * Public domain
+ * machine/endian.h compatibility shim
+ */
+
+#ifndef LIBCRYPTOCOMPAT_BYTE_ORDER_H_
+#define LIBCRYPTOCOMPAT_BYTE_ORDER_H_
+
+#if defined(_WIN32)
+
+#define LITTLE_ENDIAN  1234
+#define BIG_ENDIAN 4321
+#define PDP_ENDIAN	3412
+
+/*
+ * Use GCC and Visual Studio compiler defines to determine endian.
+ */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define BYTE_ORDER LITTLE_ENDIAN
+#else
+#define BYTE_ORDER BIG_ENDIAN
+#endif
+
+#elif defined(__linux__)
+#include <endian.h>
+
+#elif defined(__sun) || defined(_AIX) || defined(__hpux)
+#include <sys/types.h>
+#include <arpa/nameser_compat.h>
+
+#elif defined(__sgi)
+#include <standards.h>
+#include <sys/endian.h>
+
+#else
+#include_next <machine/endian.h>
+
+#endif
+
+#endif

--- a/include/md5.h
+++ b/include/md5.h
@@ -6,17 +6,6 @@
 #ifdef HAVE_MD5_H
 #include_next <md5.h>
 #else
-
-#if defined(__cplusplus)
-#define	__BEGIN_DECLS	extern "C" {
-#define	__END_DECLS	};
-#else
-#define	__BEGIN_DECLS
-#define	__END_DECLS
-#endif
-
 #include "md5_openbsd.h"
-
 #include <machine/endian.h>
-
 #endif

--- a/include/md5.h
+++ b/include/md5.h
@@ -6,5 +6,14 @@
 #ifdef HAVE_MD5_H
 #include_next <md5.h>
 #else
+
+#if defined(__cplusplus)
+#define	__BEGIN_DECLS	extern "C" {
+#define	__END_DECLS	};
+#else
+#define	__BEGIN_DECLS
+#define	__END_DECLS
+#endif
+
 #include "md5_openbsd.h"
 #endif

--- a/include/md5.h
+++ b/include/md5.h
@@ -16,4 +16,7 @@
 #endif
 
 #include "md5_openbsd.h"
+
+#include <machine/endian.h>
+
 #endif

--- a/include/sha2.h
+++ b/include/sha2.h
@@ -32,4 +32,6 @@
 #define SHA512_Update(ctx, buf, len) SHA512Update(ctx, (void *)buf, len)
 #define SHA512_Final(digest, ctx) SHA512Final(digest, ctx)
 
+#include <machine/endian.h>
+
 #endif

--- a/include/sha2.h
+++ b/include/sha2.h
@@ -7,6 +7,14 @@
 #include_next <sha2.h>
 #else
 
+#if defined(__cplusplus)
+#define	__BEGIN_DECLS	extern "C" {
+#define	__END_DECLS	};
+#else
+#define	__BEGIN_DECLS
+#define	__END_DECLS
+#endif
+
 #include "sha2_openbsd.h"
 
 #define __weak_alias(alias,sym)

--- a/include/sha2.h
+++ b/include/sha2.h
@@ -6,15 +6,6 @@
 #ifdef HAVE_SHA2_H
 #include_next <sha2.h>
 #else
-
-#if defined(__cplusplus)
-#define	__BEGIN_DECLS	extern "C" {
-#define	__END_DECLS	};
-#else
-#define	__BEGIN_DECLS
-#define	__END_DECLS
-#endif
-
 #include "sha2_openbsd.h"
 
 #define __weak_alias(alias,sym)

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -1,0 +1,30 @@
+/*
+ * Public domain
+ * stdio.h compatibility shim
+ */
+
+#include_next <stdio.h>
+
+#ifndef LIBCRYPTOCOMPAT_STDIO_H
+#define LIBCRYPTOCOMPAT_STDIO_H
+
+#ifndef HAVE_ASPRINTF
+#include <stdarg.h>
+int vasprintf(char **str, const char *fmt, va_list ap);
+int asprintf(char **str, const char *fmt, ...);
+#endif
+
+#ifdef _WIN32
+#include <errno.h>
+#include <string.h>
+
+static inline void
+posix_perror(const char *s)
+{
+	fprintf(stderr, "%s: %s\n", s, strerror(errno));
+}
+
+#define perror(errnum) posix_perror(errnum)
+#endif
+
+#endif

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -1,0 +1,19 @@
+/*
+ * Public domain
+ * sys/mman.h compatibility shim
+ */
+
+#include_next <sys/mman.h>
+
+#ifndef LIBCRYPTOCOMPAT_MMAN_H
+#define LIBCRYPTOCOMPAT_MMAN_H
+
+#ifndef MAP_ANON
+#ifdef MAP_ANONYMOUS
+#define MAP_ANON MAP_ANONYMOUS
+#else
+#error "System does not support mapping anonymous pages?"
+#endif
+#endif
+
+#endif


### PR DESCRIPTION
HI,
I'm trying to port openntpd to hpux,
and I found these include files are needed for non *bsd and linux system.
these additional include files are copied from libressl work.
Thanks.
