### PR TITLE
Add sys/wait.h stub header with WAIT_ANY definition for systems (such as

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -7,6 +7,7 @@ noinst_HEADERS += sys/socket.h
 noinst_HEADERS += sys/types.h
 noinst_HEADERS += sys/time.h
 noinst_HEADERS += sys/mman.h
+noinst_HEADERS += sys/wait.h
 noinst_HEADERS += err.h
 noinst_HEADERS += ifaddrs.h
 noinst_HEADERS += imsg.h

--- a/include/sys/wait.h
+++ b/include/sys/wait.h
@@ -1,0 +1,15 @@
+/*
+ * Public domain
+ * sys/wait.h compatibility shim
+ */
+
+#include_next <sys/wait.h>
+
+#ifndef LIBCOMPAT_SYS_WAIT_H
+#define LIBCOMPAT_SYS_WAIT_H
+
+#ifndef WAIT_ANY
+#define WAIT_ANY (-1) /* Any process. */
+#endif
+
+#endif


### PR DESCRIPTION
Solaris and illumos based distributions) which don't have it.
