### PR TITLE
Fix for issue #35 options like -v -s are not passed to the new processes

### DIFF
--- a/patches/0008-initialize-setproctitle-where-needed.patch
+++ b/patches/0008-initialize-setproctitle-where-needed.patch
@@ -36,7 +36,7 @@ index 463600a..70e5ae7 100644
  	if (strcmp(__progname, "ntpctl") == 0) {
  		ctl_main(argc, argv);
  		/* NOTREACHED */
-@@ -147,6 +156,16 @@ main(int argc, char *argv[])
+@@ -147,6 +156,17 @@ main(int argc, char *argv[])
  
  	memset(&lconf, 0, sizeof(lconf));
  
@@ -48,6 +48,7 @@ index 463600a..70e5ae7 100644
 +	saved_argv[i] = NULL;
 +	compat_init_setproctitle(argc, argv);
 +	argv = saved_argv;
++	argv0 = argv;
 +#endif
 +
  	while ((ch = getopt(argc, argv, "df:nP:p:sSv")) != -1) {


### PR DESCRIPTION
On platform where setproctitle() is not defined and SPT_TYPE =SPT_REUSEARGV the setproctitle emulation create a copy of the main arguments passed by argv in ntpd.c main() but to the the new child process uses the original arguments that are referenced by local variable argv0 = argv which are truncated in function compat_init_setproctitle() line 104, the side effect is that child process receive only process name but not the options.
My fix update local variable argv0 to the copy of original argv so new child process get all original arguments.