### PR TITLE
Provide fallback definition for __packed

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -22,6 +22,10 @@
 # define __bounded__(x, y, z)
 #endif
 
+#if !defined(HAVE_ATTRIBUTE__PACKED) && !defined(__packed)
+# define __packed	__attribute__((__packed__))
+#endif
+
 /*
  * Define BSD-style unsigned bits types for systems that do not have them.
  */

--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -69,6 +69,7 @@ case $host_os in
 		HOST_ABI=elf
 		AC_DEFINE([HAVE_ATTRIBUTE__BOUNDED__], [1], [OpenBSD gcc has bounded])
 		AC_DEFINE([HAVE_ATTRIBUTE__DEAD], [1], [OpenBSD gcc has __dead])
+		AC_DEFINE([HAVE_ATTRIBUTE__PACKED], [1], [OpenBSD gcc has __packed])
 		;;
 	*solaris*)
 		HOST_OS=solaris


### PR DESCRIPTION
Otherwise, systems that don't support it will treat it as a name for a
global `struct ntp_msg` variable.