### PR TITLE
Add constraint_reset() stub when libtls is not available

### DIFF
--- a/src/constraint-disabled.c
+++ b/src/constraint-disabled.c
@@ -67,6 +67,11 @@ constraint_add(struct constraint *cstr)
 }
 
 void
+constraint_reset(void)
+{
+}
+
+void
 constraint_msg_dns(u_int32_t id, u_int8_t *data, size_t len)
 {
 }


### PR DESCRIPTION
This prevents a linking error since ntp_dispatch_imsg calls
constraint_reset().