### PR TITLE
Fix overflow in computation of constraint_median with 32-bit time_t

### DIFF
--- a/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
+++ b/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
@@ -1,7 +1,7 @@
-From 48abb94a8b660342c5a75d2e110590fa48f4032a Mon Sep 17 00:00:00 2001
+From c4831992ad38da8771d3e7056820ce7eb36281c6 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:10:22 -0600
-Subject: [PATCH 01/20] Handle IPv6 DNS records on IPv4 networks more liberally
+Subject: [PATCH 01/21] Handle IPv6 DNS records on IPv4 networks more liberally
 
 Rather than fail on IPv4 only networks when seeing an IPv6 DNS record,
 just give a warning.
@@ -37,5 +37,5 @@ index 10924fc1ce3..1a5b22c63a3 100644
  		if (p->addr->ss.ss_family == qa4->sa_family) {
  			if (bind(p->query.fd, qa4, SA_LEN(qa4)) == -1)
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
+++ b/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
@@ -1,7 +1,7 @@
-From 3e67a7ad9a59f67a95ad8a3ebc6964ec038e87a4 Mon Sep 17 00:00:00 2001
+From 6382b740b72ec49f8ef5d96b4d4205e1aaa6d6dd Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:04:08 -0600
-Subject: [PATCH 02/20] EAI_NODATA does not exist everywhere
+Subject: [PATCH 02/21] EAI_NODATA does not exist everywhere
 
 FreeBSD says it is deprecated #ifdef's it out.
 
@@ -36,5 +36,5 @@ index 0dd2978de3a..e243818c255 100644
  		log_warnx("could not parse \"%s\": %s", s,
  		    gai_strerror(error));
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
+++ b/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
@@ -1,7 +1,7 @@
-From 018c62acc656e309de1e8a5eb0e2f1d72445a34f Mon Sep 17 00:00:00 2001
+From d12057cb557d8800a897a9aa416dc7f647283fa5 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:02:50 -0600
-Subject: [PATCH 03/20] conditionally fill in sin_len/sin6_len if they exist
+Subject: [PATCH 03/21] conditionally fill in sin_len/sin6_len if they exist
 
 ---
  src/usr.sbin/ntpd/parse.y | 8 +++++---
@@ -33,5 +33,5 @@ index 3aa8d95a9af..9130d938f41 100644
  				yyerror("invalid IPv4 or IPv6 address: %s\n",
  				    $3);
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0004-check-if-rdomain-support-is-available.patch
+++ b/patches/0004-check-if-rdomain-support-is-available.patch
@@ -1,7 +1,7 @@
-From 795ed25696dbb44c8aaf6a7d304e70df8019b0ac Mon Sep 17 00:00:00 2001
+From 85d572e229e750d34806060efc4a04ec5863f5ca Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:05:46 -0600
-Subject: [PATCH 04/20] check if rdomain support is available.
+Subject: [PATCH 04/21] check if rdomain support is available.
 
 Handle FreeBSD's calling rdomain 'FIB'.
  - from naddy@openbsd.org
@@ -94,5 +94,5 @@ index 123b6939a2b..8c18eb7610d 100644
  		if (bind(la->fd, (struct sockaddr *)&la->sa,
  		    SA_LEN((struct sockaddr *)&la->sa)) == -1) {
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
+++ b/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
@@ -1,7 +1,7 @@
-From d24e3072debf98b10de0dd2517e24acf59a08d11 Mon Sep 17 00:00:00 2001
+From 089929b2c15cec98e7f446a30f13d49989539904 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:20:03 -0600
-Subject: [PATCH 05/20] update ntpd.conf to indicate OS-dependent options
+Subject: [PATCH 05/21] update ntpd.conf to indicate OS-dependent options
 
 Also, clarify listening behavior based on a patch from
 Dererk <dererk@debian.org>
@@ -49,5 +49,5 @@ index 080dbc18bcc..ecc52fe6964 100644
  .Xr ntpd 8
  will use each given sensor that actually exists.
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0006-allow-overriding-default-user-and-file-locations.patch
+++ b/patches/0006-allow-overriding-default-user-and-file-locations.patch
@@ -1,7 +1,7 @@
-From 2d70487c3d5ee8a3ddd44be0ef1c1493525e123f Mon Sep 17 00:00:00 2001
+From 3ba5dbb3f8af21b486170c9161b42010e1747bae Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Thu, 1 Jan 2015 07:18:11 -0600
-Subject: [PATCH 06/20] allow overriding default user and file locations
+Subject: [PATCH 06/21] allow overriding default user and file locations
 
 Allow the build process to override the default ntpd file paths and
 default user.
@@ -38,5 +38,5 @@ index 16a2fe2944d..581434e86ed 100644
  #define	INTERVAL_QUERY_NORMAL		30	/* sync to peers every n secs */
  #define	INTERVAL_QUERY_PATHETIC		60
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0007-add-p-option-to-create-a-pid-file.patch
+++ b/patches/0007-add-p-option-to-create-a-pid-file.patch
@@ -1,7 +1,7 @@
-From 4772afb3c5f126a89107d3df31e0b6dcc906e771 Mon Sep 17 00:00:00 2001
+From d304deffff96e8f642720ee33b6cc16455067e31 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Wed, 31 Dec 2014 08:26:41 -0600
-Subject: [PATCH 07/20] add -p option to create a pid file
+Subject: [PATCH 07/21] add -p option to create a pid file
 
 This is used in both the Gentoo and Debian ports.
 
@@ -146,5 +146,5 @@ index 581434e86ed..31025fd4922 100644
  
  struct ctl_show_status {
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0008-initialize-setproctitle-where-needed.patch
+++ b/patches/0008-initialize-setproctitle-where-needed.patch
@@ -1,7 +1,7 @@
-From 0106c6786faf92d625669609a66466d3a83d4cb4 Mon Sep 17 00:00:00 2001
+From efd6a3b20b6095aa5c4bd0be0d6d9e8cecb0da3c Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 12 Jan 2015 06:18:31 -0600
-Subject: [PATCH 08/20] initialize setproctitle where needed
+Subject: [PATCH 08/21] initialize setproctitle where needed
 
 We need to save a copy of argv and __progname to avoid setproctitle
 clobbering them.
@@ -55,5 +55,5 @@ index 0e7672433d2..5c7239f9c8b 100644
  		switch (ch) {
  		case 'd':
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
+++ b/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
@@ -1,7 +1,7 @@
-From 85a6b49cd9ec737bc57e0c5b1baaf6e470b2d45d Mon Sep 17 00:00:00 2001
+From 72c7a629334822a96a787c89d5a510f15a833708 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Fri, 27 Mar 2015 23:14:15 -0500
-Subject: [PATCH 09/20] Notify the user when constraint support is disabled.
+Subject: [PATCH 09/21] Notify the user when constraint support is disabled.
 
 Update the manpage and warn if constraints are
 configured but ntpd is built without libtls present.
@@ -66,5 +66,5 @@ index ecc52fe6964..07b731db866 100644
  .It Ic constraint from Ar url [ip...]
  Specify the URL, IP address or the hostname of an HTTPS server to
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
+++ b/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
@@ -1,7 +1,7 @@
-From bda7461e2b610b006869ae5ea8cc8f07929d3ae4 Mon Sep 17 00:00:00 2001
+From 2dfad887e70c65d9bac666985687cb7df13f8881 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 4 May 2015 04:27:29 -0500
-Subject: [PATCH 10/20] add a method for updating the realtime clock on sync
+Subject: [PATCH 10/21] add a method for updating the realtime clock on sync
 
 from Christian Weisgerber
 ---
@@ -29,5 +29,5 @@ index 5c7239f9c8b..99f866b44b1 100644
  }
  
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
+++ b/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
@@ -1,7 +1,7 @@
-From 90b002ee4dd6a552e0cd9c6ef8cf81153e96c0ce Mon Sep 17 00:00:00 2001
+From b94795d7f916a0c8dfb8c7f84431cf3a2af27b6d Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sun, 6 Dec 2015 22:35:38 -0600
-Subject: [PATCH 11/20] Deal with missing SO_TIMESTAMP
+Subject: [PATCH 11/21] Deal with missing SO_TIMESTAMP
 
 from Paul B. Henson" <henson@acm.org>
 
@@ -57,5 +57,5 @@ index 1a5b22c63a3..95220289f21 100644
  	ntp_getmsg((struct sockaddr *)&p->addr->ss, buf, size, &msg);
  
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0012-check-result-of-ftello-ftruncate.patch
+++ b/patches/0012-check-result-of-ftello-ftruncate.patch
@@ -1,7 +1,7 @@
-From b04321d98694c20a3062a5628182bdfabbb3fac2 Mon Sep 17 00:00:00 2001
+From 5d1867a93bb35dbae519cdf19746235057ccccdb Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Mon, 21 Dec 2015 05:53:20 -0600
-Subject: [PATCH 12/20] check result of ftello/ftruncate
+Subject: [PATCH 12/21] check result of ftello/ftruncate
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 7 +++++--
@@ -33,5 +33,5 @@ index 99f866b44b1..fb9e2a6dce0 100644
  }
  
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
+++ b/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
@@ -1,7 +1,7 @@
-From 2cbf4e7ae596243b435ae9b94eaa0fda3134293e Mon Sep 17 00:00:00 2001
+From b93a16e6296f158f031f7ee7b4630b3a81775a0c Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sat, 13 Aug 2016 14:22:02 -0500
-Subject: [PATCH 13/20] set IPV6_V6ONLY if we are binding to an IPv6 address
+Subject: [PATCH 13/21] set IPV6_V6ONLY if we are binding to an IPv6 address
 
 ---
  src/usr.sbin/ntpd/server.c | 9 +++++++++
@@ -35,5 +35,5 @@ index 8c18eb7610d..9eab1a74bfe 100644
  		if (la->rtable != -1 &&
  		    setsockopt(la->fd, SOL_SOCKET, SO_RTABLE, &la->rtable,
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0014-increase-buffer-sizes-potential-truncation.patch
+++ b/patches/0014-increase-buffer-sizes-potential-truncation.patch
@@ -1,7 +1,7 @@
-From b3531dd93b6d3096287d17c4cba5898d0a279d52 Mon Sep 17 00:00:00 2001
+From b85625261bc1381a4f5f12f522c7ca2c65cd641c Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Sat, 13 Apr 2019 04:45:22 -0500
-Subject: [PATCH 14/20] increase buffer sizes potential truncation
+Subject: [PATCH 14/21] increase buffer sizes potential truncation
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 2 +-
@@ -35,5 +35,5 @@ index be113ba856b..65eb9018bb4 100644
  	b[0] = 0;
  	if (r > 0)
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0015-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
+++ b/patches/0015-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
@@ -1,7 +1,7 @@
-From 1d654b9d2ad5ae7d0c671297f5115aa5328ce09e Mon Sep 17 00:00:00 2001
+From 6a802145a4001cc79dbd3e141ff1e8a253a696eb Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:10 -0500
-Subject: [PATCH 15/20] Don't retry DNS if Checking Disable flag is not
+Subject: [PATCH 15/21] Don't retry DNS if Checking Disable flag is not
  available.
 
 ---
@@ -69,5 +69,5 @@ index 72a00deabc9..9fbc935c88e 100644
  		/* give programs like unwind a second chance */
  		sleep(1);
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0016-handle-KERN_SECURELVL-when-available.patch
+++ b/patches/0016-handle-KERN_SECURELVL-when-available.patch
@@ -1,7 +1,7 @@
-From 61d9775f4378bbdcfca255de5a6f5a1f84fee349 Mon Sep 17 00:00:00 2001
+From c7a0ea52472e28cdc72a9f0b8530c57b4136fa52 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:53 -0500
-Subject: [PATCH 16/20] handle KERN_SECURELVL when available
+Subject: [PATCH 16/21] handle KERN_SECURELVL when available
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 8 ++++++--
@@ -39,5 +39,5 @@ index da96eac94a6..73dea42f9da 100644
  	return !cnf->settime && (constraints || cnf->trusted_peers ||
  	    conf->trusted_sensors) && securelevel == 0;
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0017-initialize-deadline.patch
+++ b/patches/0017-initialize-deadline.patch
@@ -1,7 +1,7 @@
-From e7a30157501ac66e8930130ec68ee360028ebe3a Mon Sep 17 00:00:00 2001
+From 543342d3075de33880eb6a775cb6febae4b66c53 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:54:12 -0500
-Subject: [PATCH 17/20] initialize deadline
+Subject: [PATCH 17/21] initialize deadline
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 2 +-
@@ -21,5 +21,5 @@ index 73dea42f9da..bb3cc7c0bd7 100644
  
  	__progname = get_progname(argv[0]);
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0018-cast-mode-to-unsigned-int-for-Solaris.patch
+++ b/patches/0018-cast-mode-to-unsigned-int-for-Solaris.patch
@@ -1,7 +1,7 @@
-From 032b6be31452d54d188662a214220f687f674e7f Mon Sep 17 00:00:00 2001
+From 4dc62689c5c802b5defa9dce50710863ae417fdf Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:10 -0600
-Subject: [PATCH 18/20] cast mode to unsigned int for Solaris
+Subject: [PATCH 18/21] cast mode to unsigned int for Solaris
 
 ---
  src/usr.sbin/ntpd/ntp.c | 2 +-
@@ -21,5 +21,5 @@ index 4112ceb4b66..9db9f59b3ec 100644
  	if (chroot(pw->pw_dir) == -1)
  		fatal("chroot");
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0019-initialize-peercount.patch
+++ b/patches/0019-initialize-peercount.patch
@@ -1,7 +1,7 @@
-From 11f29c0b275b15a68577cb908e4e1ecfc6d93402 Mon Sep 17 00:00:00 2001
+From d1f8d6cccf3e531e31accf7375c364ffc37a72b1 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:40 -0600
-Subject: [PATCH 19/20] initialize peercount
+Subject: [PATCH 19/21] initialize peercount
 
 gcc on several platforms complains about this. It might not be a problem
 but it's not clear from the state machine.
@@ -23,5 +23,5 @@ index 9db9f59b3ec..a3914e44990 100644
  
  	if (((n = imsg_read(ibuf_dns)) == -1 && errno != EAGAIN) || n == 0)
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0020-rename-sun-to-saddr-since-sun-is-already-defined-on-.patch
+++ b/patches/0020-rename-sun-to-saddr-since-sun-is-already-defined-on-.patch
@@ -1,7 +1,7 @@
-From 96175d0e83934ba8723926215a0a44486455eeb7 Mon Sep 17 00:00:00 2001
+From c2f0e5e09a4264a656aeb5be7911272f7c9c665e Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:23:22 -0600
-Subject: [PATCH 20/20] rename 'sun' to 'saddr' since sun is already defined on
+Subject: [PATCH 20/21] rename 'sun' to 'saddr' since sun is already defined on
  Solaris
 
 This is a clearer name anyway.
@@ -39,5 +39,5 @@ index b86e615e86c..c92b447dbeb 100644
  		close(fd);
  		return (-1);
 -- 
-2.37.3
+2.42.0
 

--- a/patches/0021-Fix-integer-overflow-if-time_t-is-32-bit.patch
+++ b/patches/0021-Fix-integer-overflow-if-time_t-is-32-bit.patch
@@ -1,0 +1,31 @@
+From df39ae6f676fc705b1def90c0765915db8b21dbf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michael=20La=C3=9F?= <bevan@bi-co.net>
+Date: Fri, 8 Sep 2023 21:06:05 +0200
+Subject: [PATCH 21/21] Fix integer overflow if time_t is 32 bit
+
+Adding two time_t values representing the current time overflows if the
+underlying type is a 32 bit integer. Use long long for the addition
+which should always consist of at least 64 bit.
+
+This fixes constraints erroneously considered invalid due to an
+incorrectly computed median.
+---
+ src/usr.sbin/ntpd/constraint.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/usr.sbin/ntpd/constraint.c b/src/usr.sbin/ntpd/constraint.c
+index 8f54597a066..678916b967b 100644
+--- a/src/usr.sbin/ntpd/constraint.c
++++ b/src/usr.sbin/ntpd/constraint.c
+@@ -842,7 +842,7 @@ constraint_update(void)
+ 	/* calculate median */
+ 	i = cnt / 2;
+ 	if (cnt % 2 == 0)
+-		conf->constraint_median = (values[i - 1] + values[i]) / 2;
++		conf->constraint_median = ((long long)values[i - 1] + values[i]) / 2;
+ 	else
+ 		conf->constraint_median = values[i];
+ 
+-- 
+2.42.0
+


### PR DESCRIPTION
On system where `time_t` is a signed 32-bit integer (e.g., glibc on 32-bit x86), currently the computation of `conf->constraint_median` causes an integer overflow. Subsequently, all time sources are considered invalid due to a high deviation from the constraint.

This PR adds a patch that uses `long long` for the computation, which fixes this issue with 32-bit x86 glibc and should not harm other systems. If the cast should be avoided, an alternative with slightly larger rounding error would be something like
```
conf->constraint_median = (values[i - 1] / 2 + values[i] / 2);
```