### PR TITLE
fix incompatible check for libc compat

### DIFF
--- a/m4/check-libc-compat.m4
+++ b/m4/check-libc-compat.m4
@@ -1,6 +1,6 @@
 AC_DEFUN([CHECK_PROGNAME], [
 AC_CACHE_CHECK([if libc defines __progname], ac_cv_libc_defines___progname, [
-       AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]],
                 [[ extern char *__progname; printf("%s", __progname); ]])],
         [ ac_cv_libc_defines___progname="yes" ],
         [ ac_cv_libc_defines___progname="no"


### PR DESCRIPTION
It relied on implicit function declarations, which are banned starting in c99. Result: the check always failed.

See: https://wiki.gentoo.org/wiki/Modern_C_porting#How_do_I_reproduce_these_bugs.3F
Bug: https://bugs.gentoo.org/900296