### PR TITLE
use --runstatedir and --localstatedir for socket and drift file paths respectively

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,3 +94,25 @@ jobs:
 
       - name: "make check"
         run: make check
+
+  test-out-of-tree:
+    name: "Out-of-tree build (ubuntu-24.04)"
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'openntpd' || github.event_name != 'schedule' }}
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: "autogen"
+        run: ./autogen.sh
+
+      - name: "configure (out of tree)"
+        run: mkdir _build && cd _build && ../configure
+
+      - name: "make"
+        run: make -C _build
+
+      - name: "make check"
+        run: make -C _build check

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ parse.c
 sensors.c
 server.c
 util.c
+
+src/*.in

--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,11 @@ AC_CHECK_MEMBERS([struct sockaddr_in.sin_len], , ,
 	  #include <sys/socket.h> ]
 )
 
+# runstatedir was added as a standard directory in autoconf 2.70; provide a
+# fallback for older versions so @runstatedir@ is always substituted.
+AS_IF([test "x$runstatedir" = x], [runstatedir='${localstatedir}/run'])
+AC_SUBST([runstatedir])
+
 AC_ARG_WITH([privsep-user],
 	AS_HELP_STRING([--with-privsep-user=user],
 		       [Privilege separation user for ntpd to use]),

--- a/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
+++ b/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
@@ -1,7 +1,7 @@
 From 7f1da580cdf8f7f009ba4bda03a4378b799fbc45 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:10:22 -0600
-Subject: [PATCH 01/18] Handle IPv6 DNS records on IPv4 networks more liberally
+Subject: [PATCH 01/19] Handle IPv6 DNS records on IPv4 networks more liberally
 
 Rather than fail on IPv4 only networks when seeing an IPv6 DNS record,
 just give a warning.

--- a/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
+++ b/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
@@ -1,7 +1,7 @@
 From 479b8cc1944e609ac3582a58d7ea94d7becca044 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:04:08 -0600
-Subject: [PATCH 02/18] EAI_NODATA does not exist everywhere
+Subject: [PATCH 02/19] EAI_NODATA does not exist everywhere
 
 FreeBSD says it is deprecated #ifdef's it out.
 

--- a/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
+++ b/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
@@ -1,7 +1,7 @@
 From d0f2d6c7622f5908d745ca5cfe49c89ea5707bf8 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:02:50 -0600
-Subject: [PATCH 03/18] conditionally fill in sin_len/sin6_len if they exist
+Subject: [PATCH 03/19] conditionally fill in sin_len/sin6_len if they exist
 
 ---
  src/usr.sbin/ntpd/parse.y | 8 +++++---

--- a/patches/0004-check-if-rdomain-support-is-available.patch
+++ b/patches/0004-check-if-rdomain-support-is-available.patch
@@ -1,7 +1,7 @@
 From b8d86d85f1edee4f02ecfc6339e873fe9f535f7a Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:05:46 -0600
-Subject: [PATCH 04/18] check if rdomain support is available.
+Subject: [PATCH 04/19] check if rdomain support is available.
 
 Handle FreeBSD's calling rdomain 'FIB'.
  - from naddy@openbsd.org

--- a/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
+++ b/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
@@ -1,7 +1,7 @@
 From c05c2f442ee633239d8dd88c0b2ddb53ec363040 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:20:03 -0600
-Subject: [PATCH 05/18] update ntpd.conf to indicate OS-dependent options
+Subject: [PATCH 05/19] update ntpd.conf to indicate OS-dependent options
 
 Also, clarify listening behavior based on a patch from
 Dererk <dererk@debian.org>

--- a/patches/0006-allow-overriding-default-user-and-file-locations.patch
+++ b/patches/0006-allow-overriding-default-user-and-file-locations.patch
@@ -1,19 +1,43 @@
-From 78ffec9c413ce1495c2d9afcb219a71619d0a385 Mon Sep 17 00:00:00 2001
+From c160ef5dc4312ef336c83ebb459b09a414fa69be Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Thu, 1 Jan 2015 07:18:11 -0600
-Subject: [PATCH 06/18] allow overriding default user and file locations
+Subject: [PATCH 06/19] allow overriding default user and file locations
 
 Allow the build process to override the default ntpd file paths and
-default user.
+default user. On some systems, runstatedir can be a tmpfs, so we need to
+create the parent path on start there.
 ---
- src/usr.sbin/ntpd/ntpd.h | 16 +++++++++++++---
- 1 file changed, 13 insertions(+), 3 deletions(-)
+ src/usr.sbin/ntpd/ntpd.c |  4 ++++
+ src/usr.sbin/ntpd/ntpd.h | 13 ++++++++++---
+ 2 files changed, 14 insertions(+), 3 deletions(-)
 
+diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
+index 46a38aba8e0..550225283f0 100644
+--- a/src/usr.sbin/ntpd/ntpd.c
++++ b/src/usr.sbin/ntpd/ntpd.c
+@@ -20,6 +20,7 @@
+ #include <sys/types.h>
+ #include <sys/resource.h>
+ #include <sys/socket.h>
++#include <sys/stat.h>
+ #include <sys/sysctl.h>
+ #include <sys/wait.h>
+ #include <sys/un.h>
+@@ -258,6 +259,9 @@ main(int argc, char *argv[])
+ 	if (chdir("/") == -1)
+ 		fatal("chdir(\"/\")");
+ 
++	if (mkdir(RUNSTATEDIR, 0755) == -1 && errno != EEXIST)
++		fatal("mkdir %s", RUNSTATEDIR);
++
+ 	signal(SIGCHLD, sighdlr);
+ 
+ 	/* fork child process */
 diff --git a/src/usr.sbin/ntpd/ntpd.h b/src/usr.sbin/ntpd/ntpd.h
-index b09fc030133..77bbcd94f46 100644
+index b09fc030133..3c4399658e1 100644
 --- a/src/usr.sbin/ntpd/ntpd.h
 +++ b/src/usr.sbin/ntpd/ntpd.h
-@@ -36,10 +36,20 @@
+@@ -36,10 +36,17 @@
  
  #define MAXIMUM(a, b)	((a) > (b) ? (a) : (b))
  
@@ -29,11 +53,8 @@ index b09fc030133..77bbcd94f46 100644
 +#endif
 +#define	CONFFILE	SYSCONFDIR "/ntpd.conf"
 +
-+#ifndef	LOCALSTATEDIR
-+#define	LOCALSTATEDIR	"/var"
-+#endif
-+#define	DRIFTFILE	LOCALSTATEDIR "/db/ntpd.drift"
-+#define	CTLSOCKET	LOCALSTATEDIR "/run/ntpd.sock"
++#define	DRIFTFILE	LOCALSTATEDIR "/ntpd.drift"
++#define	CTLSOCKET	RUNSTATEDIR "/ntpd.sock"
  
  #define	INTERVAL_QUERY_NORMAL		30	/* sync to peers every n secs */
  #define	INTERVAL_QUERY_PATHETIC		60

--- a/patches/0007-add-p-option-to-create-a-pid-file.patch
+++ b/patches/0007-add-p-option-to-create-a-pid-file.patch
@@ -1,7 +1,7 @@
-From 1d699111089406c5d5dc715aa9baf1019eb94f98 Mon Sep 17 00:00:00 2001
+From 99bd1406c952b88b238d3fa1f7ee8a5f32157c2b Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Wed, 31 Dec 2014 08:26:41 -0600
-Subject: [PATCH 07/18] add -p option to create a pid file
+Subject: [PATCH 07/19] add -p option to create a pid file
 
 This is used in both the Gentoo and Debian ports.
 
@@ -134,10 +134,10 @@ index 46a38aba8e0..1d980945ea1 100644
  			timeout = INFTIM;
  			break;
 diff --git a/src/usr.sbin/ntpd/ntpd.h b/src/usr.sbin/ntpd/ntpd.h
-index 77bbcd94f46..4d8abc577d5 100644
+index d87927b9c28..69dd2336a26 100644
 --- a/src/usr.sbin/ntpd/ntpd.h
 +++ b/src/usr.sbin/ntpd/ntpd.h
-@@ -262,6 +262,7 @@ struct ntpd_conf {
+@@ -259,6 +259,7 @@ struct ntpd_conf {
  	u_int8_t					*ca;
  	size_t						ca_len;
  	int						tmpfail;

--- a/patches/0008-initialize-setproctitle-where-needed.patch
+++ b/patches/0008-initialize-setproctitle-where-needed.patch
@@ -1,7 +1,7 @@
-From b960771a2d26311d912c43c24b991cd612684887 Mon Sep 17 00:00:00 2001
+From 36d65c7d54da8292bf5ebf61492c4961ca07f6b4 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 12 Jan 2015 06:18:31 -0600
-Subject: [PATCH 08/18] initialize setproctitle where needed
+Subject: [PATCH 08/19] initialize setproctitle where needed
 
 We need to save a copy of argv and __progname to avoid setproctitle
 clobbering them.

--- a/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
+++ b/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
@@ -1,7 +1,7 @@
-From 821b490b0f0e69145ac173edf275da1271637537 Mon Sep 17 00:00:00 2001
+From 16d00fc3c8a0c00b39e871c0ca90f88b5341ddb4 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Fri, 27 Mar 2015 23:14:15 -0500
-Subject: [PATCH 09/18] Notify the user when constraint support is disabled.
+Subject: [PATCH 09/19] Notify the user when constraint support is disabled.
 
 Update the manpage and warn if constraints are
 configured but ntpd is built without libtls present.

--- a/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
+++ b/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
@@ -1,7 +1,7 @@
-From 5a28b1e214f7f1f0f7fd8ce1297c56377143e8bf Mon Sep 17 00:00:00 2001
+From e5df36e933fde1ff88d08aa339015fe208965bf2 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 4 May 2015 04:27:29 -0500
-Subject: [PATCH 10/18] add a method for updating the realtime clock on sync
+Subject: [PATCH 10/19] add a method for updating the realtime clock on sync
 
 from Christian Weisgerber
 ---

--- a/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
+++ b/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
@@ -1,7 +1,7 @@
-From d5b42fbc892775ae0167abe32d032ce936cbaec6 Mon Sep 17 00:00:00 2001
+From 5711220ecd4bb355d299f13554bd614366262832 Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sun, 6 Dec 2015 22:35:38 -0600
-Subject: [PATCH 11/18] Deal with missing SO_TIMESTAMP
+Subject: [PATCH 11/19] Deal with missing SO_TIMESTAMP
 
 from Paul B. Henson" <henson@acm.org>
 

--- a/patches/0012-check-result-of-ftello-ftruncate.patch
+++ b/patches/0012-check-result-of-ftello-ftruncate.patch
@@ -1,7 +1,7 @@
-From c3cfd13759ff506b5b7bd448e09c30902f82bb1e Mon Sep 17 00:00:00 2001
+From a295ace2f062ecf0d842d745e6ef734dd0098ce0 Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Mon, 21 Dec 2015 05:53:20 -0600
-Subject: [PATCH 12/18] check result of ftello/ftruncate
+Subject: [PATCH 12/19] check result of ftello/ftruncate
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 7 +++++--

--- a/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
+++ b/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
@@ -1,7 +1,7 @@
-From beeba6085d21a57b10fbba1f78662f952f413024 Mon Sep 17 00:00:00 2001
+From cf105a5fcb305a7a755e59d19c5b5097c51cd6ea Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sat, 13 Aug 2016 14:22:02 -0500
-Subject: [PATCH 13/18] set IPV6_V6ONLY if we are binding to an IPv6 address
+Subject: [PATCH 13/19] set IPV6_V6ONLY if we are binding to an IPv6 address
 
 ---
  src/usr.sbin/ntpd/server.c | 9 +++++++++

--- a/patches/0014-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
+++ b/patches/0014-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
@@ -1,7 +1,7 @@
-From 99006f8613ea2e09ae0404bc05ce63343cb6ce09 Mon Sep 17 00:00:00 2001
+From 0357e06866a907381ded328d5ef68473b3bc3d99 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:10 -0500
-Subject: [PATCH 14/18] Don't retry DNS if Checking Disable flag is not
+Subject: [PATCH 14/19] Don't retry DNS if Checking Disable flag is not
  available.
 
 ---

--- a/patches/0015-handle-KERN_SECURELVL-when-available.patch
+++ b/patches/0015-handle-KERN_SECURELVL-when-available.patch
@@ -1,7 +1,7 @@
-From 91a3e1398a45aa51347dc6107a04c3350ff9750b Mon Sep 17 00:00:00 2001
+From 3d1c51d587c7062c138d69c1c9ee1c0c12657117 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:53 -0500
-Subject: [PATCH 15/18] handle KERN_SECURELVL when available
+Subject: [PATCH 15/19] handle KERN_SECURELVL when available
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 8 ++++++--
@@ -11,17 +11,17 @@ diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
 index a95048dd88f..6ca0bfedb9b 100644
 --- a/src/usr.sbin/ntpd/ntpd.c
 +++ b/src/usr.sbin/ntpd/ntpd.c
-@@ -20,7 +20,9 @@
- #include <sys/types.h>
+@@ -21,7 +21,9 @@
  #include <sys/resource.h>
  #include <sys/socket.h>
+ #include <sys/stat.h>
 +#ifdef KERN_SECURELVL
  #include <sys/sysctl.h>
 +#endif
  #include <sys/wait.h>
  #include <sys/un.h>
  #include <netinet/in.h>
-@@ -119,12 +121,14 @@ usage(void)
+@@ -120,12 +122,14 @@ usage(void)
  int
  auto_preconditions(const struct ntpd_conf *cnf)
  {

--- a/patches/0016-cast-mode-to-unsigned-int-for-Solaris.patch
+++ b/patches/0016-cast-mode-to-unsigned-int-for-Solaris.patch
@@ -1,7 +1,7 @@
-From cd100a92d7e5f166ad04784343b85b8a593e3569 Mon Sep 17 00:00:00 2001
+From 75e5b27c8340768bc29ed61668d17376daf5c45b Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:10 -0600
-Subject: [PATCH 16/18] cast mode to unsigned int for Solaris
+Subject: [PATCH 16/19] cast mode to unsigned int for Solaris
 
 ---
  src/usr.sbin/ntpd/ntp.c | 2 +-

--- a/patches/0017-initialize-peercount.patch
+++ b/patches/0017-initialize-peercount.patch
@@ -1,7 +1,7 @@
-From a9c57826e9ce9f54b9858ed0cc606812106ab992 Mon Sep 17 00:00:00 2001
+From e2abe2872c29a71bbe591eb937e086eb2147fe91 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:40 -0600
-Subject: [PATCH 17/18] initialize peercount
+Subject: [PATCH 17/19] initialize peercount
 
 gcc on several platforms complains about this. It might not be a problem
 but it's not clear from the state machine.

--- a/patches/0018-allow-overiding-the-constraint-path.patch
+++ b/patches/0018-allow-overiding-the-constraint-path.patch
@@ -1,7 +1,7 @@
-From fbb10ad657ee6a2865ef993f89b8b3ec50c4bcfe Mon Sep 17 00:00:00 2001
+From 8453dddde6f2b55928833dfda994315dc43e2a14 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 20 Apr 2026 21:40:43 -0500
-Subject: [PATCH 18/18] allow overiding the constraint path
+Subject: [PATCH 18/19] allow overiding the constraint path
 
 ---
  src/usr.sbin/ntpd/constraint.c | 7 ++++++-

--- a/patches/0019-update-file-paths-with-template-placeholders.patch
+++ b/patches/0019-update-file-paths-with-template-placeholders.patch
@@ -1,4 +1,4 @@
-From 706e0d83b35385644766221bdeb37ee6e75ab192 Mon Sep 17 00:00:00 2001
+From 04c08b1f669266e338e32a42907ebef15dc0e3dd Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Sun, 26 Apr 2026 04:06:18 -0500
 Subject: [PATCH 19/19] update file paths with template placeholders
@@ -10,7 +10,7 @@ Subject: [PATCH 19/19] update file paths with template placeholders
  3 files changed, 10 insertions(+), 12 deletions(-)
 
 diff --git a/src/usr.sbin/ntpd/ntpctl.8 b/src/usr.sbin/ntpd/ntpctl.8
-index ff1e4872d..d3f5fb08e 100644
+index ff1e4872dd9..d3e3dee7be9 100644
 --- a/src/usr.sbin/ntpd/ntpctl.8
 +++ b/src/usr.sbin/ntpd/ntpctl.8
 @@ -63,8 +63,8 @@ system call, is displayed.
@@ -19,13 +19,13 @@ index ff1e4872d..d3f5fb08e 100644
  .Sh FILES
 -.Bl -tag -width "/var/run/ntpd.sockXXX" -compact
 -.It Pa /var/run/ntpd.sock
-+.Bl -tag -width "@localstatedir@/run/ntpd.sockXX" -compact
-+.It Pa @localstatedir@/run/ntpd.sock
++.Bl -tag -width "@runstatedir@/ntpd.sockXX" -compact
++.It Pa @runstatedir@/ntpd.sock
  Socket file for communication with
  .Xr ntpd 8 .
  .El
 diff --git a/src/usr.sbin/ntpd/ntpd.8 b/src/usr.sbin/ntpd/ntpd.8
-index b3f0e43f9..728b4d1b2 100644
+index b3f0e43f991..385a5c0087f 100644
 --- a/src/usr.sbin/ntpd/ntpd.8
 +++ b/src/usr.sbin/ntpd/ntpd.8
 @@ -56,7 +56,7 @@ Use
@@ -42,24 +42,24 @@ index b3f0e43f9..728b4d1b2 100644
  .Xr ntpd.conf 5 ,
  and its initial clock drift from
 -.Pa /var/db/ntpd.drift .
-+.Pa @localstatedir@/db/ntpd.drift .
++.Pa @localstatedir@/ntpd.drift .
  Clock drift is periodically written to the drift file thereafter.
  .Sh FILES
 -.Bl -tag -width "/var/db/ntpd.driftXXX" -compact
 -.It Pa /etc/ntpd.conf
-+.Bl -tag -width "@localstatedir@/db/ntpd.driftXX" -compact
++.Bl -tag -width "@localstatedir@/ntpd.driftXX" -compact
 +.It Pa @sysconfdir@/ntpd.conf
  Default configuration file.
 -.It Pa /var/db/ntpd.drift
-+.It Pa @localstatedir@/db/ntpd.drift
++.It Pa @localstatedir@/ntpd.drift
  Drift file.
 -.It Pa /var/run/ntpd.sock
-+.It Pa @localstatedir@/run/ntpd.sock
++.It Pa @runstatedir@/ntpd.sock
  Socket file for communication with
  .Xr ntpctl 8 .
  .El
 diff --git a/src/usr.sbin/ntpd/ntpd.conf.5 b/src/usr.sbin/ntpd/ntpd.conf.5
-index 9f5664cff..63ea15a68 100644
+index 9f5664cff21..63ea15a6815 100644
 --- a/src/usr.sbin/ntpd/ntpd.conf.5
 +++ b/src/usr.sbin/ntpd/ntpd.conf.5
 @@ -258,13 +258,11 @@ constraints from "https://www.google.com/"
@@ -79,5 +79,5 @@ index 9f5664cff..63ea15a68 100644
  .Sh SEE ALSO
  .Xr ntpctl 8 ,
 -- 
-2.50.1 (Apple Git-155)
+2.53.0
 

--- a/patches/0019-update-file-paths-with-template-placeholders.patch
+++ b/patches/0019-update-file-paths-with-template-placeholders.patch
@@ -1,0 +1,83 @@
+From 706e0d83b35385644766221bdeb37ee6e75ab192 Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Sun, 26 Apr 2026 04:06:18 -0500
+Subject: [PATCH 19/19] update file paths with template placeholders
+
+---
+ src/usr.sbin/ntpd/ntpctl.8    |  4 ++--
+ src/usr.sbin/ntpd/ntpd.8      | 12 ++++++------
+ src/usr.sbin/ntpd/ntpd.conf.5 |  6 ++----
+ 3 files changed, 10 insertions(+), 12 deletions(-)
+
+diff --git a/src/usr.sbin/ntpd/ntpctl.8 b/src/usr.sbin/ntpd/ntpctl.8
+index ff1e4872d..d3f5fb08e 100644
+--- a/src/usr.sbin/ntpd/ntpctl.8
++++ b/src/usr.sbin/ntpd/ntpctl.8
+@@ -63,8 +63,8 @@ system call, is displayed.
+ When the median constraint is set, the offset to the local time is displayed.
+ .El
+ .Sh FILES
+-.Bl -tag -width "/var/run/ntpd.sockXXX" -compact
+-.It Pa /var/run/ntpd.sock
++.Bl -tag -width "@localstatedir@/run/ntpd.sockXX" -compact
++.It Pa @localstatedir@/run/ntpd.sock
+ Socket file for communication with
+ .Xr ntpd 8 .
+ .El
+diff --git a/src/usr.sbin/ntpd/ntpd.8 b/src/usr.sbin/ntpd/ntpd.8
+index b3f0e43f9..728b4d1b2 100644
+--- a/src/usr.sbin/ntpd/ntpd.8
++++ b/src/usr.sbin/ntpd/ntpd.8
+@@ -56,7 +56,7 @@ Use
+ .Ar file
+ as the configuration file,
+ instead of the default
+-.Pa /etc/ntpd.conf .
++.Pa @sysconfdir@/ntpd.conf .
+ .It Fl n
+ Configtest mode.
+ Only check the configuration file for validity.
+@@ -118,15 +118,15 @@ starts up, it reads settings from its configuration file,
+ typically
+ .Xr ntpd.conf 5 ,
+ and its initial clock drift from
+-.Pa /var/db/ntpd.drift .
++.Pa @localstatedir@/db/ntpd.drift .
+ Clock drift is periodically written to the drift file thereafter.
+ .Sh FILES
+-.Bl -tag -width "/var/db/ntpd.driftXXX" -compact
+-.It Pa /etc/ntpd.conf
++.Bl -tag -width "@localstatedir@/db/ntpd.driftXX" -compact
++.It Pa @sysconfdir@/ntpd.conf
+ Default configuration file.
+-.It Pa /var/db/ntpd.drift
++.It Pa @localstatedir@/db/ntpd.drift
+ Drift file.
+-.It Pa /var/run/ntpd.sock
++.It Pa @localstatedir@/run/ntpd.sock
+ Socket file for communication with
+ .Xr ntpctl 8 .
+ .El
+diff --git a/src/usr.sbin/ntpd/ntpd.conf.5 b/src/usr.sbin/ntpd/ntpd.conf.5
+index 9f5664cff..63ea15a68 100644
+--- a/src/usr.sbin/ntpd/ntpd.conf.5
++++ b/src/usr.sbin/ntpd/ntpd.conf.5
+@@ -258,13 +258,11 @@ constraints from "https://www.google.com/"
+ .Ed
+ .El
+ .Sh FILES
+-.Bl -tag -width /etc/examples/ntpd.conf -compact
+-.It Pa /etc/ntpd.conf
++.Bl -tag -width @sysconfdir@/ntpd.conf -compact
++.It Pa @sysconfdir@/ntpd.conf
+ Default
+ .Xr ntpd 8
+ configuration file.
+-.It Pa /etc/examples/ntpd.conf
+-Example configuration file.
+ .El
+ .Sh SEE ALSO
+ .Xr ntpctl 8 ,
+-- 
+2.50.1 (Apple Git-155)
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,10 +19,24 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -DYYSTYPE_IS_DECLARED
 
 ACLOCAL_AMFLAGS = -Im4
-CLEANFILES = parse.c
+CLEANFILES = parse.c ntpctl.8 ntpd.8 ntpd.conf.5
+
+do_subst = sed \
+	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
+	-e 's,[@]localstatedir[@],$(localstatedir),g'
+
+ntpd.8: ntpd.8.in Makefile
+	$(do_subst) < $< > $@
+
+ntpd.conf.5: ntpd.conf.5.in Makefile
+	$(do_subst) < $< > $@
+
+ntpctl.8: ntpctl.8.in Makefile
+	$(do_subst) < $< > $@
 
 sbin_PROGRAMS = ntpd
-dist_man_MANS = ntpctl.8 ntpd.8 ntpd.conf.5
+nodist_man_MANS = ntpctl.8 ntpd.8 ntpd.conf.5
+EXTRA_DIST = ntpctl.8.in ntpd.8.in ntpd.conf.5.in
 
 ntpd_CFLAGS = $(CFLAGS)
 ntpd_CFLAGS += -DSYSCONFDIR=\"$(sysconfdir)\"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,16 +23,18 @@ CLEANFILES = parse.c ntpctl.8 ntpd.8 ntpd.conf.5
 
 do_subst = sed \
 	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
-	-e 's,[@]localstatedir[@],$(localstatedir),g'
+	-e 's,[@]localstatedir[@],$(localstatedir),g' \
+	-e 's,[@]runstatedir[@],$(runstatedir),g' \
+	-e 's,[@]sbindir[@],$(sbindir),g'
 
-ntpd.8: ntpd.8.in Makefile
-	$(do_subst) < $< > $@
+ntpd.8: $(srcdir)/ntpd.8.in Makefile
+	$(do_subst) < $(srcdir)/ntpd.8.in > ntpd.8
 
-ntpd.conf.5: ntpd.conf.5.in Makefile
-	$(do_subst) < $< > $@
+ntpd.conf.5: $(srcdir)/ntpd.conf.5.in Makefile
+	$(do_subst) < $(srcdir)/ntpd.conf.5.in > ntpd.conf.5
 
-ntpctl.8: ntpctl.8.in Makefile
-	$(do_subst) < $< > $@
+ntpctl.8: $(srcdir)/ntpctl.8.in Makefile
+	$(do_subst) < $(srcdir)/ntpctl.8.in > ntpctl.8
 
 sbin_PROGRAMS = ntpd
 nodist_man_MANS = ntpctl.8 ntpd.8 ntpd.conf.5
@@ -41,6 +43,7 @@ EXTRA_DIST = ntpctl.8.in ntpd.8.in ntpd.conf.5.in
 ntpd_CFLAGS = $(CFLAGS)
 ntpd_CFLAGS += -DSYSCONFDIR=\"$(sysconfdir)\"
 ntpd_CFLAGS += -DLOCALSTATEDIR=\"$(localstatedir)\"
+ntpd_CFLAGS += -DRUNSTATEDIR=\"$(runstatedir)\"
 
 ntpd_LDADD = $(PLATFORM_LDADD) $(PROG_LDADD) -lm
 ntpd_LDADD += $(top_builddir)/compat/libcompat.la
@@ -78,11 +81,11 @@ install-exec-hook:
 	@if [ ! -d "$(DESTDIR)$(sysconfdir)" ]; then \
 		$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)"; \
 	fi
-	@if [ ! -d "$(DESTDIR)$(localstatedir)/run" ]; then \
-		$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/run"; \
+	@if [ ! -d "$(DESTDIR)$(localstatedir)" ]; then \
+		$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)"; \
 	fi
-	@if [ ! -d "$(DESTDIR)$(localstatedir)/db" ]; then \
-		$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/db"; \
+	@if [ ! -d "$(DESTDIR)$(runstatedir)" ]; then \
+		$(INSTALL) -m 755 -d "$(DESTDIR)$(runstatedir)"; \
 	fi
 	@if egrep "^$(PRIVSEP_USER):" /etc/group >/dev/null; then \
 		: ; \

--- a/update.sh
+++ b/update.sh
@@ -71,4 +71,7 @@ for i in ../patches/*.patch; do
 	echo Patching ${i}
 	${PATCH} -p4 < "${i}"
 done
+mv ntpd.8 ntpd.8.in
+mv ntpd.conf.5 ntpd.conf.5.in
+mv ntpctl.8 ntpctl.8.in
 )


### PR DESCRIPTION
Also update the man page paths to reflect the configured paths.

Fixes #81 and #82 