### PR TITLE
Portable fixes from @arachsys's port, add systemd unit for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ server.c
 util.c
 
 src/*.in
+!src/openntpd.service.in

--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -31,6 +31,10 @@ libcompat_la_LIBADD = $(PLATFORM_LDADD)
 
 libcompat_la_SOURCES += socket.c
 
+if HAVE_ADJTIMEX
+libcompat_la_SOURCES += adjtime_adjtimex.c
+endif
+
 if !HAVE_ADJFREQ
 if HOST_FREEBSD
 libcompat_la_SOURCES += adjfreq_freebsd.c

--- a/compat/adjfreq_linux.c
+++ b/compat/adjfreq_linux.c
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/timex.h>
 
@@ -21,6 +22,36 @@
 
 #include <ntp.h>
 #include <ntpd.h>
+
+/*
+ * Implement adjtime() via adjtimex() to avoid EINVAL on musl libc when the
+ * delta exceeds its supported range, which causes ntpd to behave incorrectly.
+ */
+
+int
+adjtime(const struct timeval *delta, struct timeval *olddelta)
+{
+	struct timex txc = { 0 };
+
+	if (delta != NULL) {
+		txc.modes = ADJ_OFFSET_SINGLESHOT;
+		txc.offset = (long)delta->tv_sec * 1000000L + delta->tv_usec;
+	}
+
+	if (adjtimex(&txc) == -1)
+		return (-1);
+
+	if (olddelta != NULL) {
+		olddelta->tv_sec = txc.offset / 1000000L;
+		olddelta->tv_usec = txc.offset % 1000000L;
+		if (olddelta->tv_usec < 0) {
+			olddelta->tv_sec--;
+			olddelta->tv_usec += 1000000L;
+		}
+	}
+
+	return (0);
+}
 
 /*
  * adjfreq (old)freq = nanosec. per seconds shifted left 32 bits

--- a/compat/adjfreq_linux.c
+++ b/compat/adjfreq_linux.c
@@ -24,36 +24,6 @@
 #include <ntpd.h>
 
 /*
- * Implement adjtime() via adjtimex() to avoid EINVAL on musl libc when the
- * delta exceeds its supported range, which causes ntpd to behave incorrectly.
- */
-
-int
-adjtime(const struct timeval *delta, struct timeval *olddelta)
-{
-	struct timex txc = { 0 };
-
-	if (delta != NULL) {
-		txc.modes = ADJ_OFFSET_SINGLESHOT;
-		txc.offset = (long)delta->tv_sec * 1000000L + delta->tv_usec;
-	}
-
-	if (adjtimex(&txc) == -1)
-		return (-1);
-
-	if (olddelta != NULL) {
-		olddelta->tv_sec = txc.offset / 1000000L;
-		olddelta->tv_usec = txc.offset % 1000000L;
-		if (olddelta->tv_usec < 0) {
-			olddelta->tv_sec--;
-			olddelta->tv_usec += 1000000L;
-		}
-	}
-
-	return (0);
-}
-
-/*
  * adjfreq (old)freq = nanosec. per seconds shifted left 32 bits
  * timex.freq is ppm / left shifted by SHIFT_USEC (16 bits), defined in timex.h
  */

--- a/compat/adjtime_adjtimex.c
+++ b/compat/adjtime_adjtimex.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Chris Webb <chris@arachsys.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/time.h>
+#include <sys/timex.h>
+#include <errno.h>
+
+int adjtime(const struct timeval *in, struct timeval *out)
+{
+	struct timex tx = { 0 };
+	if (in) {
+		if (in->tv_sec > 1000 || in->tv_usec > 1000000000) {
+			errno = EINVAL;
+			return -1;
+		}
+		tx.offset = in->tv_sec*1000000 + in->tv_usec;
+		tx.modes = ADJ_OFFSET_SINGLESHOT;
+	}
+	if (adjtimex(&tx) < 0)
+		return -1;
+	if (out) {
+		out->tv_sec = tx.offset / 1000000;
+		if ((out->tv_usec = tx.offset % 1000000) < 0) {
+			out->tv_sec--;
+			out->tv_usec += 1000000;
+		}
+	}
+	return 0;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -63,10 +63,14 @@ AM_CONDITIONAL([HAVE_ADJTIMEX], [test "x$ac_cv_func_adjtimex" = xyes])
 AM_CONDITIONAL([HAVE_CLOCK_GETRES], [test "x$ac_cv_func_clock_getres" = xyes])
 AM_CONDITIONAL([HAVE_CLOCK_GETTIME], [test "x$ac_cv_func_clock_gettime" = xyes])
 
-# check for libtls
-AC_SEARCH_LIBS([tls_config_set_ca_mem],[tls],
-	       [LIBS="$LIBS -ltls -lssl -lcrypto"],,[-lssl -lcrypto])
+# check for libtls; explicitly add -ltls to LIBS so AC_CHECK_FUNCS and the
+# tls_write arity check below both link against it
+saved_LIBS="$LIBS"
+LIBS="$LIBS -ltls -lssl -lcrypto"
 AC_CHECK_FUNCS([tls_config_set_ca_mem])
+if test "x$ac_cv_func_tls_config_set_ca_mem" = xno; then
+	LIBS="$saved_LIBS"
+fi
 
 # check if libtls uses 3-argument tls_write
 AC_CACHE_CHECK([if tls_write takes 3 arguments], ac_cv_have_tls_write_3_arg, [

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ AC_SEARCH_LIBS([clock_gettime],[rt posix4])
 AC_CHECK_FUNCS([adjfreq ntp_adjtime adjtimex])
 AC_CHECK_FUNCS([clock_gettime clock_getres])
 AM_CONDITIONAL([HAVE_ADJFREQ], [test "x$ac_cv_func_adjfreq" = xyes])
+AM_CONDITIONAL([HAVE_ADJTIMEX], [test "x$ac_cv_func_adjtimex" = xyes])
 AM_CONDITIONAL([HAVE_CLOCK_GETRES], [test "x$ac_cv_func_clock_getres" = xyes])
 AM_CONDITIONAL([HAVE_CLOCK_GETTIME], [test "x$ac_cv_func_clock_gettime" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,15 @@ AC_CHECK_MEMBERS([struct sockaddr_in.sin_len], , ,
 AS_IF([test "x$runstatedir" = x], [runstatedir='${localstatedir}/run'])
 AC_SUBST([runstatedir])
 
+AC_ARG_WITH([systemdunitdir],
+	AS_HELP_STRING([--with-systemdunitdir=DIR],
+		       [Directory for systemd unit files (default: no install)]),
+	[systemdunitdir=$withval],
+	[systemdunitdir='']
+)
+AM_CONDITIONAL([HAVE_SYSTEMD], [test -n "$systemdunitdir"])
+AC_SUBST([systemdunitdir])
+
 AC_ARG_WITH([privsep-user],
 	AS_HELP_STRING([--with-privsep-user=user],
 		       [Privilege separation user for ntpd to use]),

--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ AM_CONDITIONAL([HAVE_CLOCK_GETTIME], [test "x$ac_cv_func_clock_gettime" = xyes])
 # check for libtls; explicitly add -ltls to LIBS so AC_CHECK_FUNCS and the
 # tls_write arity check below both link against it
 saved_LIBS="$LIBS"
-LIBS="$LIBS -ltls -lssl -lcrypto"
+LIBS="$LIBS -ltls"
 AC_CHECK_FUNCS([tls_config_set_ca_mem])
 if test "x$ac_cv_func_tls_config_set_ca_mem" = xno; then
 	LIBS="$saved_LIBS"

--- a/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
+++ b/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
@@ -1,7 +1,7 @@
 From 7f1da580cdf8f7f009ba4bda03a4378b799fbc45 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:10:22 -0600
-Subject: [PATCH 01/19] Handle IPv6 DNS records on IPv4 networks more liberally
+Subject: [PATCH 01/24] Handle IPv6 DNS records on IPv4 networks more liberally
 
 Rather than fail on IPv4 only networks when seeing an IPv6 DNS record,
 just give a warning.

--- a/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
+++ b/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
@@ -1,7 +1,7 @@
 From 479b8cc1944e609ac3582a58d7ea94d7becca044 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:04:08 -0600
-Subject: [PATCH 02/19] EAI_NODATA does not exist everywhere
+Subject: [PATCH 02/24] EAI_NODATA does not exist everywhere
 
 FreeBSD says it is deprecated #ifdef's it out.
 

--- a/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
+++ b/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
@@ -1,7 +1,7 @@
 From d0f2d6c7622f5908d745ca5cfe49c89ea5707bf8 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:02:50 -0600
-Subject: [PATCH 03/19] conditionally fill in sin_len/sin6_len if they exist
+Subject: [PATCH 03/24] conditionally fill in sin_len/sin6_len if they exist
 
 ---
  src/usr.sbin/ntpd/parse.y | 8 +++++---

--- a/patches/0004-check-if-rdomain-support-is-available.patch
+++ b/patches/0004-check-if-rdomain-support-is-available.patch
@@ -1,7 +1,7 @@
 From b8d86d85f1edee4f02ecfc6339e873fe9f535f7a Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:05:46 -0600
-Subject: [PATCH 04/19] check if rdomain support is available.
+Subject: [PATCH 04/24] check if rdomain support is available.
 
 Handle FreeBSD's calling rdomain 'FIB'.
  - from naddy@openbsd.org

--- a/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
+++ b/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
@@ -1,7 +1,7 @@
 From c05c2f442ee633239d8dd88c0b2ddb53ec363040 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:20:03 -0600
-Subject: [PATCH 05/19] update ntpd.conf to indicate OS-dependent options
+Subject: [PATCH 05/24] update ntpd.conf to indicate OS-dependent options
 
 Also, clarify listening behavior based on a patch from
 Dererk <dererk@debian.org>

--- a/patches/0006-allow-overriding-default-user-and-file-locations.patch
+++ b/patches/0006-allow-overriding-default-user-and-file-locations.patch
@@ -1,7 +1,7 @@
-From c160ef5dc4312ef336c83ebb459b09a414fa69be Mon Sep 17 00:00:00 2001
+From 6d458ea430ef7d9b7f989244ad5d5a65d93b5dba Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Thu, 1 Jan 2015 07:18:11 -0600
-Subject: [PATCH 06/19] allow overriding default user and file locations
+Subject: [PATCH 06/24] allow overriding default user and file locations
 
 Allow the build process to override the default ntpd file paths and
 default user. On some systems, runstatedir can be a tmpfs, so we need to

--- a/patches/0007-add-p-option-to-create-a-pid-file.patch
+++ b/patches/0007-add-p-option-to-create-a-pid-file.patch
@@ -1,7 +1,7 @@
-From 99bd1406c952b88b238d3fa1f7ee8a5f32157c2b Mon Sep 17 00:00:00 2001
+From 53b3386274d11d1258e586040b5992e470495284 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Wed, 31 Dec 2014 08:26:41 -0600
-Subject: [PATCH 07/19] add -p option to create a pid file
+Subject: [PATCH 07/24] add -p option to create a pid file
 
 This is used in both the Gentoo and Debian ports.
 
@@ -35,10 +35,10 @@ index 6e7f515a4b0..b3f0e43f991 100644
  .Pp
  .Nm
 diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
-index 46a38aba8e0..1d980945ea1 100644
+index 550225283f0..a29fbe01425 100644
 --- a/src/usr.sbin/ntpd/ntpd.c
 +++ b/src/usr.sbin/ntpd/ntpd.c
-@@ -89,6 +89,18 @@ sighdlr(int sig)
+@@ -90,6 +90,18 @@ sighdlr(int sig)
  	}
  }
  
@@ -57,7 +57,7 @@ index 46a38aba8e0..1d980945ea1 100644
  __dead void
  usage(void)
  {
-@@ -98,7 +110,7 @@ usage(void)
+@@ -99,7 +111,7 @@ usage(void)
  		fprintf(stderr,
  		    "usage: ntpctl -s all | peers | Sensors | status\n");
  	else
@@ -66,7 +66,7 @@ index 46a38aba8e0..1d980945ea1 100644
  		    __progname);
  	exit(1);
  }
-@@ -150,7 +162,7 @@ main(int argc, char *argv[])
+@@ -151,7 +163,7 @@ main(int argc, char *argv[])
  
  	memset(&lconf, 0, sizeof(lconf));
  
@@ -75,7 +75,7 @@ index 46a38aba8e0..1d980945ea1 100644
  		switch (ch) {
  		case 'd':
  			lconf.debug = 1;
-@@ -165,6 +177,9 @@ main(int argc, char *argv[])
+@@ -166,6 +178,9 @@ main(int argc, char *argv[])
  		case 'P':
  			pname = optarg;
  			break;
@@ -85,7 +85,7 @@ index 46a38aba8e0..1d980945ea1 100644
  		case 's':
  		case 'S':
  			sopt = ch;
-@@ -243,9 +258,11 @@ main(int argc, char *argv[])
+@@ -244,9 +259,11 @@ main(int argc, char *argv[])
  	logdest = lconf.debug ? LOG_TO_STDERR : LOG_TO_SYSLOG;
  	if (!lconf.settime) {
  		log_init(logdest, lconf.verbose, LOG_DAEMON);
@@ -98,7 +98,7 @@ index 46a38aba8e0..1d980945ea1 100644
  	} else {
  		settime_deadline = getmonotime();
  		timeout = 100;
-@@ -328,9 +345,11 @@ main(int argc, char *argv[])
+@@ -332,9 +349,11 @@ main(int argc, char *argv[])
  			log_init(logdest, lconf.verbose, LOG_DAEMON);
  			log_warnx("no reply received in time, skipping initial "
  			    "time setting");
@@ -111,7 +111,7 @@ index 46a38aba8e0..1d980945ea1 100644
  		}
  
  		if (nfds > 0 && (pfd[PFD_PIPE].revents & POLLOUT))
-@@ -369,6 +388,8 @@ main(int argc, char *argv[])
+@@ -373,6 +392,8 @@ main(int argc, char *argv[])
  	imsgbuf_clear(ibuf);
  	free(ibuf);
  	log_info("Terminating");
@@ -120,7 +120,7 @@ index 46a38aba8e0..1d980945ea1 100644
  	return (0);
  }
  
-@@ -431,9 +452,11 @@ dispatch_imsg(struct ntpd_conf *lconf, int argc, char **argv)
+@@ -435,9 +456,11 @@ dispatch_imsg(struct ntpd_conf *lconf, int argc, char **argv)
  			memcpy(&d, imsg.data, sizeof(d));
  			ntpd_settime(d);
  			/* daemonize now */
@@ -134,7 +134,7 @@ index 46a38aba8e0..1d980945ea1 100644
  			timeout = INFTIM;
  			break;
 diff --git a/src/usr.sbin/ntpd/ntpd.h b/src/usr.sbin/ntpd/ntpd.h
-index d87927b9c28..69dd2336a26 100644
+index 3c4399658e1..d32feff6eef 100644
 --- a/src/usr.sbin/ntpd/ntpd.h
 +++ b/src/usr.sbin/ntpd/ntpd.h
 @@ -259,6 +259,7 @@ struct ntpd_conf {

--- a/patches/0008-initialize-setproctitle-where-needed.patch
+++ b/patches/0008-initialize-setproctitle-where-needed.patch
@@ -1,7 +1,7 @@
-From 36d65c7d54da8292bf5ebf61492c4961ca07f6b4 Mon Sep 17 00:00:00 2001
+From 0b5ff85648f0518e113e9a3cc3c3609578df220e Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 12 Jan 2015 06:18:31 -0600
-Subject: [PATCH 08/19] initialize setproctitle where needed
+Subject: [PATCH 08/24] initialize setproctitle where needed
 
 We need to save a copy of argv and __progname to avoid setproctitle
 clobbering them.
@@ -10,10 +10,10 @@ clobbering them.
  1 file changed, 20 insertions(+)
 
 diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
-index 1d980945ea1..aad47f7b843 100644
+index a29fbe01425..624c51a27ec 100644
 --- a/src/usr.sbin/ntpd/ntpd.c
 +++ b/src/usr.sbin/ntpd/ntpd.c
-@@ -133,6 +133,13 @@ auto_preconditions(const struct ntpd_conf *cnf)
+@@ -134,6 +134,13 @@ auto_preconditions(const struct ntpd_conf *cnf)
  #define PFD_PIPE		0
  #define PFD_MAX			1
  
@@ -27,7 +27,7 @@ index 1d980945ea1..aad47f7b843 100644
  int
  main(int argc, char *argv[])
  {
-@@ -153,6 +160,8 @@ main(int argc, char *argv[])
+@@ -154,6 +161,8 @@ main(int argc, char *argv[])
  	time_t			 settime_deadline = 0;
  	int			 sopt = 0;
  
@@ -36,7 +36,7 @@ index 1d980945ea1..aad47f7b843 100644
  	if (strcmp(__progname, "ntpctl") == 0) {
  		ctl_main(argc, argv);
  		/* NOTREACHED */
-@@ -162,6 +171,17 @@ main(int argc, char *argv[])
+@@ -163,6 +172,17 @@ main(int argc, char *argv[])
  
  	memset(&lconf, 0, sizeof(lconf));
  

--- a/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
+++ b/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
@@ -1,7 +1,7 @@
-From 16d00fc3c8a0c00b39e871c0ca90f88b5341ddb4 Mon Sep 17 00:00:00 2001
+From cdd2bf4d39808d43849399d1260f0a2a2eea93a5 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Fri, 27 Mar 2015 23:14:15 -0500
-Subject: [PATCH 09/19] Notify the user when constraint support is disabled.
+Subject: [PATCH 09/24] Notify the user when constraint support is disabled.
 
 Update the manpage and warn if constraints are
 configured but ntpd is built without libtls present.

--- a/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
+++ b/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
@@ -1,7 +1,7 @@
-From e5df36e933fde1ff88d08aa339015fe208965bf2 Mon Sep 17 00:00:00 2001
+From 118e0edfe1a85c40221875362f0347b0281552d5 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 4 May 2015 04:27:29 -0500
-Subject: [PATCH 10/19] add a method for updating the realtime clock on sync
+Subject: [PATCH 10/24] add a method for updating the realtime clock on sync
 
 from Christian Weisgerber
 ---
@@ -9,10 +9,10 @@ from Christian Weisgerber
  1 file changed, 2 insertions(+)
 
 diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
-index aad47f7b843..6a0e933cdf2 100644
+index 624c51a27ec..91b27f406fe 100644
 --- a/src/usr.sbin/ntpd/ntpd.c
 +++ b/src/usr.sbin/ntpd/ntpd.c
-@@ -57,6 +57,7 @@ const char     *ctl_lookup_option(char *, const char **);
+@@ -58,6 +58,7 @@ const char     *ctl_lookup_option(char *, const char **);
  void		show_status_msg(struct imsg *);
  void		show_peer_msg(struct imsg *, int);
  void		show_sensor_msg(struct imsg *, int);
@@ -20,7 +20,7 @@ index aad47f7b843..6a0e933cdf2 100644
  
  volatile sig_atomic_t	 quit = 0;
  volatile sig_atomic_t	 reconfig = 0;
-@@ -526,6 +527,7 @@ ntpd_adjtime(double d)
+@@ -530,6 +531,7 @@ ntpd_adjtime(double d)
  	else if (!firstadj && olddelta.tv_sec == 0 && olddelta.tv_usec == 0)
  		synced = 1;
  	firstadj = 0;

--- a/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
+++ b/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
@@ -1,7 +1,7 @@
-From 5711220ecd4bb355d299f13554bd614366262832 Mon Sep 17 00:00:00 2001
+From 835c94b80e32905b46729a8305fbacf966a40b9c Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sun, 6 Dec 2015 22:35:38 -0600
-Subject: [PATCH 11/19] Deal with missing SO_TIMESTAMP
+Subject: [PATCH 11/24] Deal with missing SO_TIMESTAMP
 
 from Paul B. Henson" <henson@acm.org>
 

--- a/patches/0012-check-result-of-ftello-ftruncate.patch
+++ b/patches/0012-check-result-of-ftello-ftruncate.patch
@@ -1,17 +1,17 @@
-From a295ace2f062ecf0d842d745e6ef734dd0098ce0 Mon Sep 17 00:00:00 2001
+From 7782bfc902f850f817412ff24765a0ef0a446600 Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Mon, 21 Dec 2015 05:53:20 -0600
-Subject: [PATCH 12/19] check result of ftello/ftruncate
+Subject: [PATCH 12/24] check result of ftello/ftruncate
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 7 +++++--
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
-index 6a0e933cdf2..a95048dd88f 100644
+index 91b27f406fe..eca3fa21e9b 100644
 --- a/src/usr.sbin/ntpd/ntpd.c
 +++ b/src/usr.sbin/ntpd/ntpd.c
-@@ -636,6 +636,7 @@ writefreq(double d)
+@@ -640,6 +640,7 @@ writefreq(double d)
  {
  	int r;
  	static int warnonce = 1;
@@ -19,7 +19,7 @@ index 6a0e933cdf2..a95048dd88f 100644
  
  	if (freqfp == NULL)
  		return 0;
-@@ -649,8 +650,10 @@ writefreq(double d)
+@@ -653,8 +654,10 @@ writefreq(double d)
  		clearerr(freqfp);
  		return 0;
  	}

--- a/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
+++ b/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
@@ -1,7 +1,7 @@
-From cf105a5fcb305a7a755e59d19c5b5097c51cd6ea Mon Sep 17 00:00:00 2001
+From 7a54fab5bfd8ec98f1d9e9d8fdd2a45bda902779 Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sat, 13 Aug 2016 14:22:02 -0500
-Subject: [PATCH 13/19] set IPV6_V6ONLY if we are binding to an IPv6 address
+Subject: [PATCH 13/24] set IPV6_V6ONLY if we are binding to an IPv6 address
 
 ---
  src/usr.sbin/ntpd/server.c | 9 +++++++++

--- a/patches/0014-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
+++ b/patches/0014-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
@@ -1,7 +1,7 @@
-From 0357e06866a907381ded328d5ef68473b3bc3d99 Mon Sep 17 00:00:00 2001
+From 66fd4d57263e7a65f2c7e3b76a5e4bf78aa59549 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:10 -0500
-Subject: [PATCH 14/19] Don't retry DNS if Checking Disable flag is not
+Subject: [PATCH 14/24] Don't retry DNS if Checking Disable flag is not
  available.
 
 ---

--- a/patches/0015-handle-KERN_SECURELVL-when-available.patch
+++ b/patches/0015-handle-KERN_SECURELVL-when-available.patch
@@ -1,14 +1,14 @@
-From 3d1c51d587c7062c138d69c1c9ee1c0c12657117 Mon Sep 17 00:00:00 2001
+From 744376e0a488f7a0d594ea6b3d4b31ac684d4b7e Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:53 -0500
-Subject: [PATCH 15/19] handle KERN_SECURELVL when available
+Subject: [PATCH 15/24] handle KERN_SECURELVL when available
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 8 ++++++--
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
-index a95048dd88f..6ca0bfedb9b 100644
+index eca3fa21e9b..5ec30d4fc38 100644
 --- a/src/usr.sbin/ntpd/ntpd.c
 +++ b/src/usr.sbin/ntpd/ntpd.c
 @@ -21,7 +21,9 @@

--- a/patches/0016-cast-mode-to-unsigned-int-for-Solaris.patch
+++ b/patches/0016-cast-mode-to-unsigned-int-for-Solaris.patch
@@ -1,7 +1,7 @@
-From 75e5b27c8340768bc29ed61668d17376daf5c45b Mon Sep 17 00:00:00 2001
+From c3dce31d9d52dc53524badf873430c5449800dae Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:10 -0600
-Subject: [PATCH 16/19] cast mode to unsigned int for Solaris
+Subject: [PATCH 16/24] cast mode to unsigned int for Solaris
 
 ---
  src/usr.sbin/ntpd/ntp.c | 2 +-

--- a/patches/0017-initialize-peercount.patch
+++ b/patches/0017-initialize-peercount.patch
@@ -1,7 +1,7 @@
-From e2abe2872c29a71bbe591eb937e086eb2147fe91 Mon Sep 17 00:00:00 2001
+From d005bf53e19f79200621d28ddc2c968efd0b857f Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:40 -0600
-Subject: [PATCH 17/19] initialize peercount
+Subject: [PATCH 17/24] initialize peercount
 
 gcc on several platforms complains about this. It might not be a problem
 but it's not clear from the state machine.

--- a/patches/0018-allow-overiding-the-constraint-path.patch
+++ b/patches/0018-allow-overiding-the-constraint-path.patch
@@ -1,7 +1,7 @@
-From 8453dddde6f2b55928833dfda994315dc43e2a14 Mon Sep 17 00:00:00 2001
+From e33efdd820329c9232f657032cb8b900a8a50d6b Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 20 Apr 2026 21:40:43 -0500
-Subject: [PATCH 18/19] allow overiding the constraint path
+Subject: [PATCH 18/24] allow overiding the constraint path
 
 ---
  src/usr.sbin/ntpd/constraint.c | 7 ++++++-

--- a/patches/0019-update-file-paths-with-template-placeholders.patch
+++ b/patches/0019-update-file-paths-with-template-placeholders.patch
@@ -1,7 +1,7 @@
-From 04c08b1f669266e338e32a42907ebef15dc0e3dd Mon Sep 17 00:00:00 2001
+From 6e319580360199778f838643238f243730637e2c Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Sun, 26 Apr 2026 04:06:18 -0500
-Subject: [PATCH 19/19] update file paths with template placeholders
+Subject: [PATCH 19/24] update file paths with template placeholders
 
 ---
  src/usr.sbin/ntpd/ntpctl.8    |  4 ++--

--- a/patches/0020-avoid-returning-zero-from-getmonotime-on-fast-bootin.patch
+++ b/patches/0020-avoid-returning-zero-from-getmonotime-on-fast-bootin.patch
@@ -1,10 +1,10 @@
-From 8ee99a8efad44ef2d6ebe7be11b875c7f916a179 Mon Sep 17 00:00:00 2001
+From c051af8789e55b58a7ca0d1e106555a129b01af8 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:41:42 -0500
 Subject: [PATCH 20/24] avoid returning zero from getmonotime on fast-booting
  systems
 
-Based on work by Chris Webb (arachsys)
+Based on work by Chris Webb <chris@arachsys.com>
 https://github.com/arachsys/openntpd/commit/90f7ed0d76f3fb89b6533209807664019adb2da6
 ---
  src/usr.sbin/ntpd/util.c | 2 +-

--- a/patches/0020-avoid-returning-zero-from-getmonotime-on-fast-bootin.patch
+++ b/patches/0020-avoid-returning-zero-from-getmonotime-on-fast-bootin.patch
@@ -1,0 +1,28 @@
+From 8ee99a8efad44ef2d6ebe7be11b875c7f916a179 Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Tue, 28 Apr 2026 21:41:42 -0500
+Subject: [PATCH 20/24] avoid returning zero from getmonotime on fast-booting
+ systems
+
+Based on work by Chris Webb (arachsys)
+https://github.com/arachsys/openntpd/commit/90f7ed0d76f3fb89b6533209807664019adb2da6
+---
+ src/usr.sbin/ntpd/util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/usr.sbin/ntpd/util.c b/src/usr.sbin/ntpd/util.c
+index a0b64ee4b92..e7bf21f1197 100644
+--- a/src/usr.sbin/ntpd/util.c
++++ b/src/usr.sbin/ntpd/util.c
+@@ -70,7 +70,7 @@ getmonotime(void)
+ 	if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+ 		fatal("clock_gettime");
+ 
+-	return (ts.tv_sec);
++	return ts.tv_sec + 1; /* don't return zero at boot */
+ }
+ 
+ 
+-- 
+2.53.0
+

--- a/patches/0021-avoid-time_t-overflow-when-calculating-constraint-me.patch
+++ b/patches/0021-avoid-time_t-overflow-when-calculating-constraint-me.patch
@@ -1,0 +1,29 @@
+From c24d92d96053a8dff69d72ae643fd6d8c4be5962 Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Tue, 28 Apr 2026 21:44:15 -0500
+Subject: [PATCH 21/24] avoid time_t overflow when calculating constraint
+ median
+
+Based on work by Chris Webb (arachsys)
+https://github.com/arachsys/openntpd/commit/931555d68d1418e0b3fbd9464ca5831693cd0bd2
+---
+ src/usr.sbin/ntpd/constraint.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/usr.sbin/ntpd/constraint.c b/src/usr.sbin/ntpd/constraint.c
+index e4b2c775697..04bb8e585a2 100644
+--- a/src/usr.sbin/ntpd/constraint.c
++++ b/src/usr.sbin/ntpd/constraint.c
+@@ -865,7 +865,8 @@ constraint_update(void)
+ 	/* calculate median */
+ 	i = cnt / 2;
+ 	if (cnt % 2 == 0)
+-		conf->constraint_median = (values[i - 1] + values[i]) / 2;
++		conf->constraint_median = values[i - 1] +
++		    (values[i] - values[i - 1]) / 2;
+ 	else
+ 		conf->constraint_median = values[i];
+ 
+-- 
+2.53.0
+

--- a/patches/0021-avoid-time_t-overflow-when-calculating-constraint-me.patch
+++ b/patches/0021-avoid-time_t-overflow-when-calculating-constraint-me.patch
@@ -1,10 +1,10 @@
-From c24d92d96053a8dff69d72ae643fd6d8c4be5962 Mon Sep 17 00:00:00 2001
+From 09f47c412d92cdef0f805824d62466ed7715ec00 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:44:15 -0500
 Subject: [PATCH 21/24] avoid time_t overflow when calculating constraint
  median
 
-Based on work by Chris Webb (arachsys)
+Based on work by Chris Webb <chris@arachsys.com>
 https://github.com/arachsys/openntpd/commit/931555d68d1418e0b3fbd9464ca5831693cd0bd2
 ---
  src/usr.sbin/ntpd/constraint.c | 3 ++-

--- a/patches/0022-ensure-kernel-sync-status-is-updated-at-startup-and-.patch
+++ b/patches/0022-ensure-kernel-sync-status-is-updated-at-startup-and-.patch
@@ -1,0 +1,58 @@
+From 1cf4f8f9ec67e6c77c93cfef43ce63ec16f5bcc4 Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Tue, 28 Apr 2026 21:44:56 -0500
+Subject: [PATCH 22/24] ensure kernel sync status is updated at startup and
+ when clock goes unsynced
+
+Based on work by Chris Webb (arachsys)
+https://github.com/arachsys/openntpd/commit/d8f531380b15f8e8082684483446926dcef339d5
+---
+ src/usr.sbin/ntpd/ntp.c  | 3 +++
+ src/usr.sbin/ntpd/ntpd.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/usr.sbin/ntpd/ntp.c b/src/usr.sbin/ntpd/ntp.c
+index db94f132d7a..ebcb4361556 100644
+--- a/src/usr.sbin/ntpd/ntp.c
++++ b/src/usr.sbin/ntpd/ntp.c
+@@ -186,6 +186,7 @@ ntp_main(struct ntpd_conf *nconf, struct passwd *pw, int argc, char **argv)
+ 	conf->freq.overall_offset = 0.0;
+ 
+ 	conf->status.synced = 0;
++	imsg_compose(ibuf_main, IMSG_UNSYNCED, 0, 0, -1, NULL, 0);
+ 	clock_getres(CLOCK_REALTIME, &tp);
+ 	b = 1000000000 / tp.tv_nsec;	/* convert to Hz */
+ 	for (a = 0; b > 1; a--, b >>= 1)
+@@ -459,6 +460,7 @@ ntp_main(struct ntpd_conf *nconf, struct passwd *pw, int argc, char **argv)
+ 			conf->status.synced = 0;
+ 			conf->scale = 1;
+ 			priv_dns(IMSG_UNSYNCED, NULL, 0);
++			imsg_compose(ibuf_main, IMSG_UNSYNCED, 0, 0, -1, NULL, 0);
+ 		}
+ 	}
+ 
+@@ -501,6 +503,7 @@ ntp_dispatch_imsg(void)
+ 				log_info("clock is now unsynced");
+ 				conf->status.synced = 0;
+ 				priv_dns(IMSG_UNSYNCED, NULL, 0);
++				imsg_compose(ibuf_main, IMSG_UNSYNCED, 0, 0, -1, NULL, 0);
+ 			}
+ 			break;
+ 		case IMSG_CONSTRAINT_RESULT:
+diff --git a/src/usr.sbin/ntpd/ntpd.c b/src/usr.sbin/ntpd/ntpd.c
+index 5ec30d4fc38..ab612ae4abc 100644
+--- a/src/usr.sbin/ntpd/ntpd.c
++++ b/src/usr.sbin/ntpd/ntpd.c
+@@ -489,6 +489,9 @@ dispatch_imsg(struct ntpd_conf *lconf, int argc, char **argv)
+ 			lconf->settime = 0;
+ 			timeout = INFTIM;
+ 			break;
++		case IMSG_UNSYNCED:
++			update_time_sync_status(0);
++			break;
+ 		case IMSG_CONSTRAINT_QUERY:
+ 			priv_constraint_msg(imsg.hdr.peerid,
+ 			    imsg.data, imsg.hdr.len - IMSG_HEADER_SIZE,
+-- 
+2.53.0
+

--- a/patches/0022-ensure-kernel-sync-status-is-updated-at-startup-and-.patch
+++ b/patches/0022-ensure-kernel-sync-status-is-updated-at-startup-and-.patch
@@ -1,10 +1,10 @@
-From 1cf4f8f9ec67e6c77c93cfef43ce63ec16f5bcc4 Mon Sep 17 00:00:00 2001
+From bc6048cf52ac579812a540ecf594563ced09ad60 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:44:56 -0500
 Subject: [PATCH 22/24] ensure kernel sync status is updated at startup and
  when clock goes unsynced
 
-Based on work by Chris Webb (arachsys)
+Based on work by Chris Webb <chris@arachsys.com>
 https://github.com/arachsys/openntpd/commit/d8f531380b15f8e8082684483446926dcef339d5
 ---
  src/usr.sbin/ntpd/ntp.c  | 3 +++

--- a/patches/0023-correct-and-invalidate-peer-sensor-offsets-when-step.patch
+++ b/patches/0023-correct-and-invalidate-peer-sensor-offsets-when-step.patch
@@ -1,0 +1,45 @@
+From d89b62970133c5cbd644e47f28322d89a2d9dff1 Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Tue, 28 Apr 2026 21:45:10 -0500
+Subject: [PATCH 23/24] correct and invalidate peer/sensor offsets when
+ stepping the clock
+
+Based on work by Chris Webb (arachsys)
+https://github.com/arachsys/openntpd/commit/616970fe88fe2280046288721d328e46311e68f8
+---
+ src/usr.sbin/ntpd/ntp.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/src/usr.sbin/ntpd/ntp.c b/src/usr.sbin/ntpd/ntp.c
+index ebcb4361556..81c12e5a5e6 100644
+--- a/src/usr.sbin/ntpd/ntp.c
++++ b/src/usr.sbin/ntpd/ntp.c
+@@ -856,8 +856,24 @@ offset_compare(const void *aa, const void *bb)
+ void
+ priv_settime(double offset, char *msg)
+ {
+-	if (offset == 0)
++	struct ntp_peer		*p;
++	struct ntp_sensor	*s;
++	int			 i;
++
++	if (offset == 0) {
+ 		log_info("cancel settime because %s", msg);
++	} else {
++		TAILQ_FOREACH(p, &conf->ntp_peers, entry) {
++			for (i = 0; i < OFFSET_ARRAY_SIZE; i++)
++				p->reply[i].offset -= offset;
++			p->update.good = 0;
++		}
++		TAILQ_FOREACH(s, &conf->ntp_sensors, entry) {
++			for (i = 0; i < SENSOR_OFFSETS; i++)
++				s->offsets[i].offset -= offset;
++			s->update.offset -= offset;
++		}
++	}
+ 	imsg_compose(ibuf_main, IMSG_SETTIME, 0, 0, -1,
+ 	    &offset, sizeof(offset));
+ 	conf->settime = 0;
+-- 
+2.53.0
+

--- a/patches/0023-correct-and-invalidate-peer-sensor-offsets-when-step.patch
+++ b/patches/0023-correct-and-invalidate-peer-sensor-offsets-when-step.patch
@@ -1,10 +1,10 @@
-From d89b62970133c5cbd644e47f28322d89a2d9dff1 Mon Sep 17 00:00:00 2001
+From c532203f3d64be315ad24864f8c1bda22ea8a4bb Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:45:10 -0500
 Subject: [PATCH 23/24] correct and invalidate peer/sensor offsets when
  stepping the clock
 
-Based on work by Chris Webb (arachsys)
+Based on work by Chris Webb <chris@arachsys.com>
 https://github.com/arachsys/openntpd/commit/616970fe88fe2280046288721d328e46311e68f8
 ---
  src/usr.sbin/ntpd/ntp.c | 18 +++++++++++++++++-

--- a/patches/0024-retry-on-all-recvmsg-and-connect-errors-rather-than-.patch
+++ b/patches/0024-retry-on-all-recvmsg-and-connect-errors-rather-than-.patch
@@ -1,0 +1,86 @@
+From c35394be164a5a9ebcfc50dbdacaf738e706a4cb Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Tue, 28 Apr 2026 21:45:20 -0500
+Subject: [PATCH 24/24] retry on all recvmsg and connect errors rather than
+ whitelisting errno values
+
+Based on work by Chris Webb (arachsys)
+https://github.com/arachsys/openntpd/commit/400c28b6c4e7b94d0f3870ce060606f8cce5fcb5
+---
+ src/usr.sbin/ntpd/client.c | 32 ++++++++++----------------------
+ src/usr.sbin/ntpd/server.c |  9 ++-------
+ 2 files changed, 12 insertions(+), 29 deletions(-)
+
+diff --git a/src/usr.sbin/ntpd/client.c b/src/usr.sbin/ntpd/client.c
+index db9b62de71c..0a5c34ece18 100644
+--- a/src/usr.sbin/ntpd/client.c
++++ b/src/usr.sbin/ntpd/client.c
+@@ -174,19 +174,13 @@ client_query(struct ntp_peer *p)
+ 		}
+ 
+ 		if (connect(p->query.fd, sa, SA_LEN(sa)) == -1) {
+-			if (errno == ECONNREFUSED || errno == ENETUNREACH ||
+-			    errno == EHOSTUNREACH || errno == EADDRNOTAVAIL) {
+-				/* cycle through addresses, but do increase
+-				   senderrors */
+-				client_nextaddr(p);
+-				if (p->addr == NULL)
+-					p->addr = p->addr_head.a;
+-				set_next(p, MAXIMUM(SETTIME_TIMEOUT,
+-				    scale_interval(INTERVAL_QUERY_AGGRESSIVE)));
+-				p->senderrors++;
+-				return (-1);
+-			} else
+-				fatal("client_query connect");
++			client_nextaddr(p);
++			if (p->addr == NULL)
++				p->addr = p->addr_head.a;
++			set_next(p, MAXIMUM(SETTIME_TIMEOUT,
++			    scale_interval(INTERVAL_QUERY_AGGRESSIVE)));
++			p->senderrors++;
++			return (-1);
+ 		}
+ 		val = IPTOS_LOWDELAY;
+ 		if (p->addr->ss.ss_family == AF_INET && setsockopt(p->query.fd,
+@@ -306,15 +300,9 @@ client_dispatch(struct ntp_peer *p, u_int8_t settime, u_int8_t automatic)
+ 	somsg.msg_controllen = sizeof(cmsgbuf.buf);
+ 
+ 	if ((size = recvmsg(p->query.fd, &somsg, 0)) == -1) {
+-		if (errno == EHOSTUNREACH || errno == EHOSTDOWN ||
+-		    errno == ENETUNREACH || errno == ENETDOWN ||
+-		    errno == ECONNREFUSED || errno == EADDRNOTAVAIL ||
+-		    errno == ENOPROTOOPT || errno == ENOENT) {
+-			client_log_error(p, "recvmsg", errno);
+-			set_next(p, error_interval());
+-			return (-1);
+-		} else
+-			fatal("recvfrom");
++		client_log_error(p, "recvmsg", errno);
++		set_next(p, error_interval());
++		return (-1);
+ 	}
+ 
+ 	if (somsg.msg_flags & MSG_TRUNC) {
+diff --git a/src/usr.sbin/ntpd/server.c b/src/usr.sbin/ntpd/server.c
+index 9eab1a74bfe..86bbf20d741 100644
+--- a/src/usr.sbin/ntpd/server.c
++++ b/src/usr.sbin/ntpd/server.c
+@@ -183,13 +183,8 @@ server_dispatch(int fd, struct ntpd_conf *lconf)
+ 	fsa_len = sizeof(fsa);
+ 	if ((size = recvfrom(fd, &buf, sizeof(buf), 0,
+ 	    (struct sockaddr *)&fsa, &fsa_len)) == -1) {
+-		if (errno == EHOSTUNREACH || errno == EHOSTDOWN ||
+-		    errno == ENETUNREACH || errno == ENETDOWN) {
+-			log_warn("recvfrom %s",
+-			    log_sockaddr((struct sockaddr *)&fsa));
+-			return (0);
+-		} else
+-			fatal("recvfrom");
++		log_warn("recvfrom");
++		return (0);
+ 	}
+ 
+ 	rectime = gettime_corrected();
+-- 
+2.53.0
+

--- a/patches/0024-retry-on-all-recvmsg-and-connect-errors-rather-than-.patch
+++ b/patches/0024-retry-on-all-recvmsg-and-connect-errors-rather-than-.patch
@@ -1,10 +1,10 @@
-From c35394be164a5a9ebcfc50dbdacaf738e706a4cb Mon Sep 17 00:00:00 2001
+From fb3df9b9df5dacc47b69765747a44d4a4478831a Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:45:20 -0500
 Subject: [PATCH 24/24] retry on all recvmsg and connect errors rather than
  whitelisting errno values
 
-Based on work by Chris Webb (arachsys)
+Based on work by Chris Webb <chris@arachsys.com>
 https://github.com/arachsys/openntpd/commit/400c28b6c4e7b94d0f3870ce060606f8cce5fcb5
 ---
  src/usr.sbin/ntpd/client.c | 32 ++++++++++----------------------

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,9 +36,18 @@ ntpd.conf.5: $(srcdir)/ntpd.conf.5.in Makefile
 ntpctl.8: $(srcdir)/ntpctl.8.in Makefile
 	$(do_subst) < $(srcdir)/ntpctl.8.in > ntpctl.8
 
+if HAVE_SYSTEMD
+systemdunitdir = @systemdunitdir@
+nodist_systemdunit_DATA = openntpd.service
+CLEANFILES += openntpd.service
+
+openntpd.service: openntpd.service.in Makefile
+	$(do_subst) < $< > $@
+endif
+
 sbin_PROGRAMS = ntpd
 nodist_man_MANS = ntpctl.8 ntpd.8 ntpd.conf.5
-EXTRA_DIST = ntpctl.8.in ntpd.8.in ntpd.conf.5.in
+EXTRA_DIST = ntpctl.8.in ntpd.8.in ntpd.conf.5.in openntpd.service.in
 
 ntpd_CFLAGS = $(CFLAGS)
 ntpd_CFLAGS += -DSYSCONFDIR=\"$(sysconfdir)\"

--- a/src/openntpd.service.in
+++ b/src/openntpd.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=OpenNTPD Network Time Protocol
+Documentation=man:openntpd(8)
+After=network.target
+
+[Service]
+Type=forking
+ExecStartPre=@sbindir@/ntpd -n $DAEMON_OPTS
+ExecStart=@sbindir@/ntpd $DAEMON_OPTS
+ExecReload=@sbindir@/ntpd -n $DAEMON_OPTS
+KillMode=process
+Restart=on-failure
+EnvironmentFile=-@sysconfdir@/default/openntpd
+RuntimeDirectory=openntpd
+RuntimeDirectoryMode=0755
+StateDirectory=openntpd
+StateDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This incorporates fixes from @arachsys's openntpd port. These correct some issues interoperating with musl libc, edge cases where the system boots before the uptime is >= 1 second, and some synchronization issues.

Testing more locally, but so far have not encountered any issues.

This also adds a systemd unit I've been using for testing.