### PR TITLE
add configurable ctl socket group

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,14 @@ AC_ARG_WITH([privsep-user],
 AC_DEFINE_UNQUOTED(NTPD_USER, "$PRIVSEP_USER", [Unprivileged user])
 AC_SUBST(PRIVSEP_USER)
 
+AC_ARG_WITH([ctl-group],
+	AS_HELP_STRING([--with-ctl-group=group],
+		[Set group ownership of ntpd control socket]),
+	[AS_IF([test "x$withval" != xyes -a "x$withval" != xno],
+		[AC_DEFINE_UNQUOTED(NTPD_GROUP, "$withval",
+		[Control socket group])])]
+)
+
 AC_ARG_WITH([cacert],
 	AS_HELP_STRING([--with-cacert=path],
 		       [CA certificate location for HTTPS constraint validation]),

--- a/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
+++ b/patches/0001-Handle-IPv6-DNS-records-on-IPv4-networks-more-libera.patch
@@ -1,7 +1,7 @@
 From 7f1da580cdf8f7f009ba4bda03a4378b799fbc45 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:10:22 -0600
-Subject: [PATCH 01/26] Handle IPv6 DNS records on IPv4 networks more liberally
+Subject: [PATCH 01/27] Handle IPv6 DNS records on IPv4 networks more liberally
 
 Rather than fail on IPv4 only networks when seeing an IPv6 DNS record,
 just give a warning.

--- a/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
+++ b/patches/0002-EAI_NODATA-does-not-exist-everywhere.patch
@@ -1,7 +1,7 @@
 From 479b8cc1944e609ac3582a58d7ea94d7becca044 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:04:08 -0600
-Subject: [PATCH 02/26] EAI_NODATA does not exist everywhere
+Subject: [PATCH 02/27] EAI_NODATA does not exist everywhere
 
 FreeBSD says it is deprecated #ifdef's it out.
 

--- a/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
+++ b/patches/0003-conditionally-fill-in-sin_len-sin6_len-if-they-exist.patch
@@ -1,7 +1,7 @@
 From d0f2d6c7622f5908d745ca5cfe49c89ea5707bf8 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:02:50 -0600
-Subject: [PATCH 03/26] conditionally fill in sin_len/sin6_len if they exist
+Subject: [PATCH 03/27] conditionally fill in sin_len/sin6_len if they exist
 
 ---
  src/usr.sbin/ntpd/parse.y | 8 +++++---

--- a/patches/0004-check-if-rdomain-support-is-available.patch
+++ b/patches/0004-check-if-rdomain-support-is-available.patch
@@ -1,7 +1,7 @@
 From b8d86d85f1edee4f02ecfc6339e873fe9f535f7a Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:05:46 -0600
-Subject: [PATCH 04/26] check if rdomain support is available.
+Subject: [PATCH 04/27] check if rdomain support is available.
 
 Handle FreeBSD's calling rdomain 'FIB'.
  - from naddy@openbsd.org

--- a/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
+++ b/patches/0005-update-ntpd.conf-to-indicate-OS-dependent-options.patch
@@ -1,7 +1,7 @@
 From c05c2f442ee633239d8dd88c0b2ddb53ec363040 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 30 Dec 2014 09:20:03 -0600
-Subject: [PATCH 05/26] update ntpd.conf to indicate OS-dependent options
+Subject: [PATCH 05/27] update ntpd.conf to indicate OS-dependent options
 
 Also, clarify listening behavior based on a patch from
 Dererk <dererk@debian.org>

--- a/patches/0006-allow-overriding-default-user-and-file-locations.patch
+++ b/patches/0006-allow-overriding-default-user-and-file-locations.patch
@@ -1,7 +1,7 @@
 From 6d458ea430ef7d9b7f989244ad5d5a65d93b5dba Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Thu, 1 Jan 2015 07:18:11 -0600
-Subject: [PATCH 06/26] allow overriding default user and file locations
+Subject: [PATCH 06/27] allow overriding default user and file locations
 
 Allow the build process to override the default ntpd file paths and
 default user. On some systems, runstatedir can be a tmpfs, so we need to

--- a/patches/0007-add-p-option-to-create-a-pid-file.patch
+++ b/patches/0007-add-p-option-to-create-a-pid-file.patch
@@ -1,7 +1,7 @@
 From 53b3386274d11d1258e586040b5992e470495284 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Wed, 31 Dec 2014 08:26:41 -0600
-Subject: [PATCH 07/26] add -p option to create a pid file
+Subject: [PATCH 07/27] add -p option to create a pid file
 
 This is used in both the Gentoo and Debian ports.
 

--- a/patches/0008-initialize-setproctitle-where-needed.patch
+++ b/patches/0008-initialize-setproctitle-where-needed.patch
@@ -1,7 +1,7 @@
 From 0b5ff85648f0518e113e9a3cc3c3609578df220e Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 12 Jan 2015 06:18:31 -0600
-Subject: [PATCH 08/26] initialize setproctitle where needed
+Subject: [PATCH 08/27] initialize setproctitle where needed
 
 We need to save a copy of argv and __progname to avoid setproctitle
 clobbering them.

--- a/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
+++ b/patches/0009-Notify-the-user-when-constraint-support-is-disabled.patch
@@ -1,7 +1,7 @@
 From cdd2bf4d39808d43849399d1260f0a2a2eea93a5 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Fri, 27 Mar 2015 23:14:15 -0500
-Subject: [PATCH 09/26] Notify the user when constraint support is disabled.
+Subject: [PATCH 09/27] Notify the user when constraint support is disabled.
 
 Update the manpage and warn if constraints are
 configured but ntpd is built without libtls present.

--- a/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
+++ b/patches/0010-add-a-method-for-updating-the-realtime-clock-on-sync.patch
@@ -1,7 +1,7 @@
 From 118e0edfe1a85c40221875362f0347b0281552d5 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 4 May 2015 04:27:29 -0500
-Subject: [PATCH 10/26] add a method for updating the realtime clock on sync
+Subject: [PATCH 10/27] add a method for updating the realtime clock on sync
 
 from Christian Weisgerber
 ---

--- a/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
+++ b/patches/0011-Deal-with-missing-SO_TIMESTAMP.patch
@@ -1,7 +1,7 @@
 From 835c94b80e32905b46729a8305fbacf966a40b9c Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sun, 6 Dec 2015 22:35:38 -0600
-Subject: [PATCH 11/26] Deal with missing SO_TIMESTAMP
+Subject: [PATCH 11/27] Deal with missing SO_TIMESTAMP
 
 from Paul B. Henson" <henson@acm.org>
 

--- a/patches/0012-check-result-of-ftello-ftruncate.patch
+++ b/patches/0012-check-result-of-ftello-ftruncate.patch
@@ -1,7 +1,7 @@
 From 7782bfc902f850f817412ff24765a0ef0a446600 Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Mon, 21 Dec 2015 05:53:20 -0600
-Subject: [PATCH 12/26] check result of ftello/ftruncate
+Subject: [PATCH 12/27] check result of ftello/ftruncate
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 7 +++++--

--- a/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
+++ b/patches/0013-set-IPV6_V6ONLY-if-we-are-binding-to-an-IPv6-address.patch
@@ -1,7 +1,7 @@
 From 7a54fab5bfd8ec98f1d9e9d8fdd2a45bda902779 Mon Sep 17 00:00:00 2001
 From: Brent Cook <bcook@openbsd.org>
 Date: Sat, 13 Aug 2016 14:22:02 -0500
-Subject: [PATCH 13/26] set IPV6_V6ONLY if we are binding to an IPv6 address
+Subject: [PATCH 13/27] set IPV6_V6ONLY if we are binding to an IPv6 address
 
 ---
  src/usr.sbin/ntpd/server.c | 9 +++++++++

--- a/patches/0014-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
+++ b/patches/0014-Don-t-retry-DNS-if-Checking-Disable-flag-is-not-avai.patch
@@ -1,7 +1,7 @@
 From 66fd4d57263e7a65f2c7e3b76a5e4bf78aa59549 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:10 -0500
-Subject: [PATCH 14/26] Don't retry DNS if Checking Disable flag is not
+Subject: [PATCH 14/27] Don't retry DNS if Checking Disable flag is not
  available.
 
 ---

--- a/patches/0015-handle-KERN_SECURELVL-when-available.patch
+++ b/patches/0015-handle-KERN_SECURELVL-when-available.patch
@@ -1,7 +1,7 @@
 From 744376e0a488f7a0d594ea6b3d4b31ac684d4b7e Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 8 Jun 2020 06:53:53 -0500
-Subject: [PATCH 15/26] handle KERN_SECURELVL when available
+Subject: [PATCH 15/27] handle KERN_SECURELVL when available
 
 ---
  src/usr.sbin/ntpd/ntpd.c | 8 ++++++--

--- a/patches/0016-cast-mode-to-unsigned-int-for-Solaris.patch
+++ b/patches/0016-cast-mode-to-unsigned-int-for-Solaris.patch
@@ -1,7 +1,7 @@
 From c3dce31d9d52dc53524badf873430c5449800dae Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:10 -0600
-Subject: [PATCH 16/26] cast mode to unsigned int for Solaris
+Subject: [PATCH 16/27] cast mode to unsigned int for Solaris
 
 ---
  src/usr.sbin/ntpd/ntp.c | 2 +-

--- a/patches/0017-initialize-peercount.patch
+++ b/patches/0017-initialize-peercount.patch
@@ -1,7 +1,7 @@
 From d005bf53e19f79200621d28ddc2c968efd0b857f Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 16 Nov 2020 02:20:40 -0600
-Subject: [PATCH 17/26] initialize peercount
+Subject: [PATCH 17/27] initialize peercount
 
 gcc on several platforms complains about this. It might not be a problem
 but it's not clear from the state machine.

--- a/patches/0018-allow-overiding-the-constraint-path.patch
+++ b/patches/0018-allow-overiding-the-constraint-path.patch
@@ -1,7 +1,7 @@
 From e33efdd820329c9232f657032cb8b900a8a50d6b Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Mon, 20 Apr 2026 21:40:43 -0500
-Subject: [PATCH 18/26] allow overiding the constraint path
+Subject: [PATCH 18/27] allow overiding the constraint path
 
 ---
  src/usr.sbin/ntpd/constraint.c | 7 ++++++-

--- a/patches/0019-update-file-paths-with-template-placeholders.patch
+++ b/patches/0019-update-file-paths-with-template-placeholders.patch
@@ -1,7 +1,7 @@
 From 6e319580360199778f838643238f243730637e2c Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Sun, 26 Apr 2026 04:06:18 -0500
-Subject: [PATCH 19/26] update file paths with template placeholders
+Subject: [PATCH 19/27] update file paths with template placeholders
 
 ---
  src/usr.sbin/ntpd/ntpctl.8    |  4 ++--

--- a/patches/0020-avoid-returning-zero-from-getmonotime-on-fast-bootin.patch
+++ b/patches/0020-avoid-returning-zero-from-getmonotime-on-fast-bootin.patch
@@ -1,7 +1,7 @@
 From da90b2699ad432bae1e97acf9177e69b78840e57 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:41:42 -0500
-Subject: [PATCH 20/26] avoid returning zero from getmonotime on fast-booting
+Subject: [PATCH 20/27] avoid returning zero from getmonotime on fast-booting
  systems
 
 Based on work by Chris Webb <chris@arachsys.com>

--- a/patches/0021-avoid-time_t-overflow-when-calculating-constraint-me.patch
+++ b/patches/0021-avoid-time_t-overflow-when-calculating-constraint-me.patch
@@ -1,7 +1,7 @@
 From abf4b03adc1d50042ddb5101215663d1bfd09a5a Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:44:15 -0500
-Subject: [PATCH 21/26] avoid time_t overflow when calculating constraint
+Subject: [PATCH 21/27] avoid time_t overflow when calculating constraint
  median
 
 Based on work by Chris Webb <chris@arachsys.com>

--- a/patches/0022-ensure-kernel-sync-status-is-updated-at-startup-and-.patch
+++ b/patches/0022-ensure-kernel-sync-status-is-updated-at-startup-and-.patch
@@ -1,7 +1,7 @@
 From 7dc485c4152b7f3cf70278cc4552bea1e57e190f Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:44:56 -0500
-Subject: [PATCH 22/26] ensure kernel sync status is updated at startup and
+Subject: [PATCH 22/27] ensure kernel sync status is updated at startup and
  when clock goes unsynced
 
 Based on work by Chris Webb <chris@arachsys.com>

--- a/patches/0023-correct-and-invalidate-peer-sensor-offsets-when-step.patch
+++ b/patches/0023-correct-and-invalidate-peer-sensor-offsets-when-step.patch
@@ -1,7 +1,7 @@
 From 5c0bebcebec937301b2b28f174e18b3c3ffee384 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:45:10 -0500
-Subject: [PATCH 23/26] correct and invalidate peer/sensor offsets when
+Subject: [PATCH 23/27] correct and invalidate peer/sensor offsets when
  stepping the clock
 
 Based on work by Chris Webb <chris@arachsys.com>

--- a/patches/0024-retry-on-all-recvmsg-and-connect-errors-rather-than-.patch
+++ b/patches/0024-retry-on-all-recvmsg-and-connect-errors-rather-than-.patch
@@ -1,7 +1,7 @@
 From 0973592f85bf8dda2abce8f0a6f3c94747479fbf Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Tue, 28 Apr 2026 21:45:20 -0500
-Subject: [PATCH 24/26] retry on all recvmsg and connect errors rather than
+Subject: [PATCH 24/27] retry on all recvmsg and connect errors rather than
  whitelisting errno values
 
 Based on work by Chris Webb <chris@arachsys.com>

--- a/patches/0025-if-a-pool-is-trusted-members-of-the-pool-are-trusted.patch
+++ b/patches/0025-if-a-pool-is-trusted-members-of-the-pool-are-trusted.patch
@@ -1,7 +1,7 @@
 From fd6d7d0cb7531d2863fe51aaaf4822a38fdae579 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Sun, 17 May 2026 07:53:48 -0500
-Subject: [PATCH 25/26] if a pool is trusted, members of the pool are trusted
+Subject: [PATCH 25/27] if a pool is trusted, members of the pool are trusted
 
 ---
  src/usr.sbin/ntpd/ntp.c | 1 +

--- a/patches/0026-if-there-are-no-constraints-don-t-wait-for-a-validat.patch
+++ b/patches/0026-if-there-are-no-constraints-don-t-wait-for-a-validat.patch
@@ -1,7 +1,7 @@
 From 2760aa01e2087ec3325a3607671895a15dd3e070 Mon Sep 17 00:00:00 2001
 From: Brent Cook <busterb@gmail.com>
 Date: Sun, 17 May 2026 07:56:03 -0500
-Subject: [PATCH 26/26] if there are no constraints, don't wait for a validated
+Subject: [PATCH 26/27] if there are no constraints, don't wait for a validated
  reply
 
 ---

--- a/patches/0027-add-ntp-ctl-group-configuration.patch
+++ b/patches/0027-add-ntp-ctl-group-configuration.patch
@@ -1,0 +1,43 @@
+From 2cd868c948803949fa8d96a46851342e0035987a Mon Sep 17 00:00:00 2001
+From: Brent Cook <busterb@gmail.com>
+Date: Sun, 17 May 2026 09:21:15 -0500
+Subject: [PATCH 27/27] add ntp ctl group configuration
+
+---
+ src/usr.sbin/ntpd/control.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/usr.sbin/ntpd/control.c b/src/usr.sbin/ntpd/control.c
+index ffe76568787..96efc9729db 100644
+--- a/src/usr.sbin/ntpd/control.c
++++ b/src/usr.sbin/ntpd/control.c
+@@ -22,6 +22,7 @@
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <errno.h>
++#include <grp.h>
+ #include <math.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -103,6 +104,18 @@ control_init(char *path)
+ 		return (-1);
+ 	}
+ 
++#ifdef NTPD_GROUP
++	struct group *gr;
++	if ((gr = getgrnam(NTPD_GROUP)) == NULL)
++		fatalx("unknown group %s", NTPD_GROUP);
++	if (chown(path, -1, gr->gr_gid) == -1) {
++		log_warn("control_init: chown");
++		close(fd);
++		(void)unlink(path);
++		return (-1);
++	}
++#endif
++
+ 	session_socket_nonblockmode(fd);
+ 
+ 	return (fd);
+-- 
+2.53.0
+


### PR DESCRIPTION
proposal for #83 

Example:
```
./configure --prefix=/usr --with-cacert --with-privsep-user=ntpd --localstatedir=/var/lib/openntpd --runstatedir=/run/openntpd --sysconfdir=/etc/openntpd --with-ctl-group=users

bcook@llama:~/openntpd-7.9p1$ ls -l /run/openntpd/
total 0
srw-rw---- 1 root users 0 May 17 09:45 ntpd.sock

bcook@llama:~/openntpd-7.9p1$ ntpctl -s status
20/20 peers valid, constraint offset 0s, clock synced, stratum 3
```

This does require chown permission in apparmor / systemd to work. I could make this a non-fatal error too.